### PR TITLE
Add B3 Propagator support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,15 @@ jobs:
       - checkout
       - run: msbuild /t:Restore
       - run: msbuild test/LightStep.Tests/LightStep.Tests.csproj /t:Test
+  publish:
+    docker:
+      - image: aparker/circleci-dotnet-mono:latest
+    steps:
+      - checkout
+      - run: msbuild /t:Restore
+      - run: msbuild /t:Build
+      - run: msbuild src/LightStep/LightStep.csproj /t:Pack
+      - run: dotnet nuget push src/LightStep/bin/Debug/*.nupkg -k $NuGet
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - checkout
       - run: msbuild /t:Restore
+      - run: msbuild /t:Build
       - run: msbuild test/LightStep.Tests/LightStep.Tests.csproj /t:Test
   publish:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,15 @@ jobs:
     steps:
       - checkout
       - run: msbuild /t:Restore
-      - run: msbuild /t:Build
+      - run: msbuild src/LightStep/LightStep.csproj /t:Build
   test:
     docker:
       - image: aparker/circleci-dotnet-mono:latest
     steps:
       - checkout
       - run: msbuild /t:Restore
-      - run: msbuild /t:Build
+      - run: msbuild src/LightStep/LightStep.csproj /t:Build
+      - run: msbuild test/LightStep.Tests/LightStep.Tests.csproj /t:Build
       - run: msbuild test/LightStep.Tests/LightStep.Tests.csproj /t:Test
   publish:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: aparker/circleci-dotnet-mono:latest
+    steps:
+      - checkout
+      - run: msbuild /t:Restore
+      - run: msbuild /t:Build
+  test:
+    docker:
+      - image: aparker/circleci-dotnet-mono:latest
+    steps:
+      - checkout
+      - run: msbuild /t:Restore
+      - run: msbuild test/LightStep.Tests/LightStep.Tests.csproj /t:Test
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,18 @@ jobs:
       - run: msbuild src/LightStep/LightStep.csproj /t:Build
       - run: msbuild test/LightStep.Tests/LightStep.Tests.csproj /t:Build
       - run: msbuild test/LightStep.Tests/LightStep.Tests.csproj /t:Test
+  pack:
+    docker:
+      - image: aparker/circleci-dotnet-mono:latest
+    steps:
+      - checkout
+      - run: msbuild /t:Restore
+      - run: msbuild src/LightStep/LightStep.csproj /t:Build
+      - run: msbuild src/LightStep/LightStep.csproj /t:Pack /p:PackageOutputPath="/pkg"
+
+      - store_artifacts:
+          path: /pkg
+          
   publish:
     docker:
       - image: aparker/circleci-dotnet-mono:latest
@@ -30,4 +42,9 @@ workflows:
   build_and_test:
     jobs:
       - build
-      - test
+      - test:
+        requires:
+          - build
+      - pack:
+        requires:
+          - test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lightstep-tracer-csharp
 The LightStep distributed tracing library for C#
 
-[![NuGet](https://img.shields.io/nuget/v/LightStep.svg)](https://www.nuget.org/packages/LightStep)
+[![NuGet](https://img.shields.io/nuget/v/LightStep.svg)](https://www.nuget.org/packages/LightStep) [![CircleCI](https://circleci.com/gh/lightstep/lightstep-tracer-csharp.svg?style=svg)](https://circleci.com/gh/lightstep/lightstep-tracer-csharp)
 
 # Installation
 Install the package via NuGet into your solution, or use `Install-Package LightStep`.

--- a/examples/LightStep.CSharpTestApp/Program.cs
+++ b/examples/LightStep.CSharpTestApp/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Threading;
 using OpenTracing.Util;
 
@@ -30,5 +31,6 @@ namespace LightStep.TestApp
 
             tracer.Flush();
         }
+        
     }
 }

--- a/src/LightStep/Collector/LightStepHttpClient.cs
+++ b/src/LightStep/Collector/LightStepHttpClient.cs
@@ -10,9 +10,10 @@ namespace LightStep.Collector
     /// <summary>
     ///     Contains methods to communicate to a LightStep Satellite via Proto over HTTP.
     /// </summary>
-    public class LightStepHttpClient : IDisposable
+    public class LightStepHttpClient
     {
         private readonly Options _options;
+        private readonly HttpClient _client;
         private readonly string _url;
 
         /// <summary>
@@ -20,14 +21,11 @@ namespace LightStep.Collector
         /// </summary>
         /// <param name="satelliteUrl">URL to send results to.</param>
         /// <param name="options">An <see cref="Options" /> object.</param>
-        public LightStepHttpClient(string satelliteUrl, Options options)
+        public LightStepHttpClient(string url, Options options)
         {
-            _url = satelliteUrl;
+            _url = url;
             _options = options;
-        }
-
-        public void Dispose()
-        {
+            _client = new HttpClient();
         }
 
         /// <summary>
@@ -37,9 +35,8 @@ namespace LightStep.Collector
         /// <returns>A <see cref="ReportResponse" />. This is usually not very interesting.</returns>
         public ReportResponse SendReport(ReportRequest report)
         {
-            var client = new HttpClient();
-
-            client.DefaultRequestHeaders.Accept.Add(
+            
+            _client.DefaultRequestHeaders.Accept.Add(
                 new MediaTypeWithQualityHeaderValue("application/octet-stream"));
 
             var request = new HttpRequestMessage(HttpMethod.Post, _url)
@@ -50,7 +47,7 @@ namespace LightStep.Collector
 
             request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
 
-            var response = client.SendAsync(request).Result;
+            var response = _client.SendAsync(request).Result;
             var responseData = response.Content.ReadAsStreamAsync().Result;
             return ReportResponse.Parser.ParseFrom(responseData);
         }

--- a/src/LightStep/LightStep.csproj
+++ b/src/LightStep/LightStep.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>LightStep</AssemblyName>
     <RootNamespace>LightStep</RootNamespace>
     <LangVersion>7.1</LangVersion>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net452;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Api.CommonProtos" Version="1.3.0" />
@@ -22,7 +22,7 @@
     <None Remove="lightstep.proto" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
       
@@ -35,7 +35,7 @@
       <Description>OpenTracing compliant tracer for LightStep.</Description>
       <Copyright>LightStep 2018</Copyright>
   </PropertyGroup>
-  
+
   <PropertyGroup>
       <PackageTags>tracing</PackageTags>
       <PackageReleaseNotes>add b3 propagator support</PackageReleaseNotes>

--- a/src/LightStep/LightStep.csproj
+++ b/src/LightStep/LightStep.csproj
@@ -25,28 +25,25 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
+      
+  <PropertyGroup>
+      <Authors>Austin Parker</Authors>
+      <PackageVersion>0.0.2-alpha-$(CIRCLE_BUILD_NUM)</PackageVersion>
+      <Company>LightStep</Company>
+      <NeutralLanguage>en-US</NeutralLanguage>
+      <AssemblyTitle>LightStep</AssemblyTitle>
+      <Description>OpenTracing compliant tracer for LightStep.</Description>
+      <Copyright>LightStep 2018</Copyright>
+  </PropertyGroup>
   
   <PropertyGroup>
-    <VersionPrefix>0.0.2</VersionPrefix>
-    <VersionSuffix>alpha</VersionSuffix>
+      <PackageTags>tracing</PackageTags>
+      <PackageReleaseNotes>add b3 propagator support</PackageReleaseNotes>
+      <PackageIconUrl>https://raw.githubusercontent.com/lightstep/lightstep-tracer-csharp/master/ls128x128.md</PackageIconUrl>
+      <PackageProjectUrl>http://www.lightstep.com</PackageProjectUrl>
+      <PackageLicenseUrl>https://raw.githubusercontent.com/lightstep/lightstep-tracer-csharp/master/LICENSE.md</PackageLicenseUrl>
+      <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+      <RepositoryType>git</RepositoryType>
+      <RepositoryUrl>https://raw.githubusercontent.com/lightstep/lightstep-tracer-csharp</RepositoryUrl>
   </PropertyGroup>
-    
-    <PropertyGroup>
-        <Authors>Austin Parker</Authors>
-        <Company>LightStep</Company>
-        <NeutralLanguage>en-US</NeutralLanguage>
-        <AssemblyTitle>LightStep</AssemblyTitle>
-        <Description>OpenTracing compliant tracer for LightStep.</Description>
-        <Copyright>LightStep 2018</Copyright>
-    </PropertyGroup>
-    <PropertyGroup>
-        <PackageTags>tracing</PackageTags>
-        <PackageReleaseNotes>add b3 propagator support</PackageReleaseNotes>
-        <PackageIconUrl>https://raw.githubusercontent.com/lightstep/lightstep-tracer-csharp/master/ls128x128.md</PackageIconUrl>
-        <PackageProjectUrl>http://www.lightstep.com</PackageProjectUrl>
-        <PackageLicenseUrl>https://raw.githubusercontent.com/lightstep/lightstep-tracer-csharp/master/LICENSE.md</PackageLicenseUrl>
-        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://raw.githubusercontent.com/lightstep/lightstep-tracer-csharp</RepositoryUrl>
-    </PropertyGroup>
 </Project>

--- a/src/LightStep/LightStep.csproj
+++ b/src/LightStep/LightStep.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>LightStep</AssemblyName>
     <RootNamespace>LightStep</RootNamespace>
     <LangVersion>7.1</LangVersion>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Api.CommonProtos" Version="1.3.0" />
@@ -22,12 +22,12 @@
     <None Remove="lightstep.proto" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
   
   <PropertyGroup>
-    <VersionPrefix>0.0.1</VersionPrefix>
+    <VersionPrefix>0.0.2</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
   </PropertyGroup>
     
@@ -41,7 +41,7 @@
     </PropertyGroup>
     <PropertyGroup>
         <PackageTags>tracing</PackageTags>
-        <PackageReleaseNotes>initial release</PackageReleaseNotes>
+        <PackageReleaseNotes>add b3 propagator support</PackageReleaseNotes>
         <PackageIconUrl>https://raw.githubusercontent.com/lightstep/lightstep-tracer-csharp/master/ls128x128.md</PackageIconUrl>
         <PackageProjectUrl>http://www.lightstep.com</PackageProjectUrl>
         <PackageLicenseUrl>https://raw.githubusercontent.com/lightstep/lightstep-tracer-csharp/master/LICENSE.md</PackageLicenseUrl>

--- a/src/LightStep/Options.cs
+++ b/src/LightStep/Options.cs
@@ -77,30 +77,23 @@ namespace LightStep
             {
                 entryAssembly = Assembly.GetEntryAssembly().GetName().Name;
             }
-            catch (NullReferenceException ex)
+            catch (NullReferenceException)
             {
                 // could not get assembly name, possibly because we're running a test
                 entryAssembly = "unknown";
-            }
-            
+            }  
             return entryAssembly;
-
-
         }
 
 
         private static string GetHostName()
         {
-
            return Environment.MachineName;
-
         }
 
         private static string GetCommandLine()
         {
-
             return Environment.CommandLine;
-
         }
     }
 }

--- a/src/LightStep/Options.cs
+++ b/src/LightStep/Options.cs
@@ -61,8 +61,8 @@ namespace LightStep
             var attributes = new Dictionary<string, object>
             {
                 [LightStepConstants.TracerPlatformKey] = LightStepConstants.TracerPlatformValue,
-                [LightStepConstants.TracerPlatformVersionKey] = "0.1",
-                [LightStepConstants.TracerVersionKey] = "0.1",
+                [LightStepConstants.TracerPlatformVersionKey] = "0.2",
+                [LightStepConstants.TracerVersionKey] = "0.2",
                 [LightStepConstants.ComponentNameKey] = GetComponentName(),
                 [LightStepConstants.HostnameKey] = GetHostName(),
                 [LightStepConstants.CommandLineKey] = GetCommandLine()

--- a/src/LightStep/Options.cs
+++ b/src/LightStep/Options.cs
@@ -72,39 +72,35 @@ namespace LightStep
 
         private static string GetComponentName()
         {
-            var compName = "";
-#if NETSTANDARD1_3
-            compName = Environment.GetEnvironmentVariable("LS_COMPONENT");
-            #endif
-#if NETSTANDARD2_0 || NET45
-            compName = Assembly.GetEntryAssembly().GetName().Name;
-#endif
-            return compName;
+            var entryAssembly = "";
+            try
+            {
+                entryAssembly = Assembly.GetEntryAssembly().GetName().Name;
+            }
+            catch (NullReferenceException ex)
+            {
+                // could not get assembly name, possibly because we're running a test
+                entryAssembly = "unknown";
+            }
+            
+            return entryAssembly;
+
+
         }
 
 
         private static string GetHostName()
         {
-            var hostname = "";
-#if NETSTANDARD1_3
-            hostname = Environment.GetEnvironmentVariable("LS_HOSTNAME");
-            #endif
-#if NETSTANDARD2_0 || NET45
-            hostname = Environment.MachineName;
-#endif
-            return hostname;
+
+           return Environment.MachineName;
+
         }
 
         private static string GetCommandLine()
         {
-            var commandLine = "";
-#if NETSTANDARD1_3
-            commandLine = Environment.GetEnvironmentVariable("LS_COMMANDLINE");
-            #endif
-#if NETSTANDARD2_0 || NET45
-            commandLine = Environment.CommandLine;
-#endif
-            return commandLine;
+
+            return Environment.CommandLine;
+
         }
     }
 }

--- a/src/LightStep/Propagation/B3Propagator.cs
+++ b/src/LightStep/Propagation/B3Propagator.cs
@@ -13,8 +13,8 @@ namespace LightStep.Propagation
         /// <inheritdoc />
         public void Inject<TCarrier>(SpanContext context, IFormat<TCarrier> format, TCarrier carrier)
         {
-            ulong traceId = Convert.ToUInt64(context.TraceId);
-            ulong spanId = Convert.ToUInt64(context.SpanId);
+            var traceId = Convert.ToUInt64(context.TraceId);
+            var spanId = Convert.ToUInt64(context.SpanId);
 
             if (carrier is ITextMap text)
             {
@@ -29,18 +29,13 @@ namespace LightStep.Propagation
         {
             string traceId = null;
             string spanId = null;
-            
+
             if (carrier is ITextMap text)
                 foreach (var entry in text)
                     if (TraceIdName.Equals(entry.Key))
-                    {
                         traceId = entry.Value;
-                    }
-                    else if (SpanIdName.Equals(entry.Key))
-                    {
-                        spanId = entry.Value;
-                    }
-                   
+                    else if (SpanIdName.Equals(entry.Key)) spanId = entry.Value;
+
             if (!string.IsNullOrEmpty(traceId) && !string.IsNullOrEmpty(spanId))
                 return new SpanContext(traceId, spanId);
 

--- a/src/LightStep/Propagation/B3Propagator.cs
+++ b/src/LightStep/Propagation/B3Propagator.cs
@@ -1,0 +1,52 @@
+using System;
+using OpenTracing.Propagation;
+
+namespace LightStep.Propagation
+{
+    /// <inheritdoc />
+    public class B3Propagator : IPropagator
+    {
+        private const string TraceIdName = "X-B3-TraceId";
+        private const string SpanIdName = "X-B3-SpanId";
+        private const string SampledName = "X-B3-Sampled";
+
+        /// <inheritdoc />
+        public void Inject<TCarrier>(SpanContext context, IFormat<TCarrier> format, TCarrier carrier)
+        {
+            ulong traceId = Convert.ToUInt64(context.TraceId);
+            ulong spanId = Convert.ToUInt64(context.SpanId);
+
+            if (carrier is ITextMap text)
+            {
+                text.Set(TraceIdName, traceId.ToString("X"));
+                text.Set(SpanIdName, spanId.ToString("X"));
+                text.Set(SampledName, "true");
+            }
+        }
+
+        /// <inheritdoc />
+        public SpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
+        {
+            string traceId = null;
+            string spanId = null;
+            
+            if (carrier is ITextMap text)
+                foreach (var entry in text)
+                    if (TraceIdName.Equals(entry.Key))
+                    {
+                        traceId = entry.Value;
+                    }
+                    else if (SpanIdName.Equals(entry.Key))
+                    {
+                        spanId = entry.Value;
+                    }
+                    else
+                        throw new InvalidOperationException($"Unknown carrier {carrier.GetType()}");
+
+            if (!string.IsNullOrEmpty(traceId) && !string.IsNullOrEmpty(spanId))
+                return new SpanContext(traceId, spanId);
+
+            return null;
+        }
+    }
+}

--- a/src/LightStep/Propagation/B3Propagator.cs
+++ b/src/LightStep/Propagation/B3Propagator.cs
@@ -40,9 +40,7 @@ namespace LightStep.Propagation
                     {
                         spanId = entry.Value;
                     }
-                    else
-                        throw new InvalidOperationException($"Unknown carrier {carrier.GetType()}");
-
+                   
             if (!string.IsNullOrEmpty(traceId) && !string.IsNullOrEmpty(spanId))
                 return new SpanContext(traceId, spanId);
 

--- a/src/LightStep/Propagation/HttpHeadersPropagator.cs
+++ b/src/LightStep/Propagation/HttpHeadersPropagator.cs
@@ -1,0 +1,25 @@
+using OpenTracing.Propagation;
+
+namespace LightStep.Propagation
+{
+    /** TODO: this is a blind copy of the Java client; once HTTP carrier encoding has been defined, update this as well
+     * 
+     */
+    /// <inheritdoc />
+    public class HttpHeadersPropagator : IPropagator
+    {
+        /// <inheritdoc />
+        public void Inject<TCarrier>(SpanContext context, IFormat<TCarrier> format, TCarrier carrier)
+        {
+            var textMapPropagator = new TextMapPropagator();
+            textMapPropagator.Inject(context, format, carrier);
+        }
+
+        /// <inheritdoc />
+        public SpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
+        {
+            var textMapPropagator = new TextMapPropagator();
+            return textMapPropagator.Extract(format, carrier);
+        }
+    }
+}

--- a/src/LightStep/Propagation/PropagatorStack.cs
+++ b/src/LightStep/Propagation/PropagatorStack.cs
@@ -36,14 +36,33 @@ namespace LightStep.Propagation
         
         public void Inject<TCarrier>(SpanContext context, IFormat<TCarrier> format, TCarrier carrier)
         {
-            Propagators.ForEach(propagator => propagator.Inject(context, format, carrier));
+            Propagators.ForEach(propagator =>
+            {
+                try
+                {
+                    propagator.Inject(context, format, carrier);
+                }
+                catch
+                {
+                    // suppress errors
+                }
+            });
         }
 
         public SpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
         {
             for (int i = Propagators.Count - 1; i >= 0; i--)
             {
-                var context = Propagators[i].Extract(format, carrier);
+                SpanContext context = null;
+                try
+                {
+                    context = Propagators[i].Extract(format, carrier);
+                }
+                catch
+                {
+                    // suppress errors
+                }
+                
                 if (context != null)
                 {
                     return context;

--- a/src/LightStep/Propagation/PropagatorStack.cs
+++ b/src/LightStep/Propagation/PropagatorStack.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTracing.Propagation;
+
+namespace LightStep.Propagation
+{
+    /// <inheritdoc />
+    public class PropagatorStack : IPropagator
+    {
+        public IFormat<ITextMap> Format { get; }
+        public List<IPropagator> Propagators { get; private set; }
+        
+        public PropagatorStack(IFormat<ITextMap> format)
+        {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+
+            Format = format;
+            Propagators = new List<IPropagator>();
+        }
+
+        public PropagatorStack AddPropagator(IPropagator propagator)
+        {
+            if (propagator == null)
+            {
+                throw new ArgumentNullException(nameof(propagator));
+            }
+            
+            Propagators.Add(propagator);
+            return this;
+        }
+        
+        public void Inject<TCarrier>(SpanContext context, IFormat<TCarrier> format, TCarrier carrier)
+        {
+            Propagators.ForEach(propagator => propagator.Inject(context, format, carrier));
+        }
+
+        public SpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
+        {
+            for (int i = Propagators.Count - 1; i >= 0; i--)
+            {
+                var context = Propagators[i].Extract(format, carrier);
+                if (context != null)
+                {
+                    return context;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/LightStep/Propagation/Propagators.cs
+++ b/src/LightStep/Propagation/Propagators.cs
@@ -19,6 +19,10 @@ namespace LightStep.Propagation
         ///    Supports B3 headers, such as those used in Zipkin or StageMonitor.
         /// </summary>
         public static readonly IPropagator B3Propagator = new B3Propagator();
+        
+        /// <summary>
+        ///     Supports HTTP Header Propagation
+        /// </summary>
+        public static readonly IPropagator HttpHeadersPropagator = new HttpHeadersPropagator();
     }
-
 }

--- a/src/LightStep/Propagation/Propagators.cs
+++ b/src/LightStep/Propagation/Propagators.cs
@@ -14,12 +14,12 @@ namespace LightStep.Propagation
         ///     A key:value store for string pairs.
         /// </summary>
         public static readonly IPropagator TextMap = new TextMapPropagator();
-        
+
         /// <summary>
-        ///    Supports B3 headers, such as those used in Zipkin or StageMonitor.
+        ///     Supports B3 headers, such as those used in Zipkin or StageMonitor.
         /// </summary>
         public static readonly IPropagator B3Propagator = new B3Propagator();
-        
+
         /// <summary>
         ///     Supports HTTP Header Propagation
         /// </summary>

--- a/src/LightStep/Propagation/Propagators.cs
+++ b/src/LightStep/Propagation/Propagators.cs
@@ -14,5 +14,11 @@ namespace LightStep.Propagation
         ///     A key:value store for string pairs.
         /// </summary>
         public static readonly IPropagator TextMap = new TextMapPropagator();
+        
+        /// <summary>
+        ///    Supports B3 headers, such as those used in Zipkin or StageMonitor.
+        /// </summary>
+        public static readonly IPropagator B3Propagator = new B3Propagator();
     }
+
 }

--- a/src/LightStep/Propagation/TextMapPropagator.cs
+++ b/src/LightStep/Propagation/TextMapPropagator.cs
@@ -43,9 +43,7 @@ namespace LightStep.Propagation
                         var key = entry.Key.Substring(Keys.BaggagePrefix.Length);
                         baggage.Set(key, entry.Value);
                     }
-            else
-                throw new InvalidOperationException($"Unknown carrier {carrier.GetType()}");
-
+            
             if (!string.IsNullOrEmpty(traceId) && !string.IsNullOrEmpty(spanId))
                 return new SpanContext(traceId, spanId, baggage);
 

--- a/src/LightStep/Propagation/TextMapPropagator.cs
+++ b/src/LightStep/Propagation/TextMapPropagator.cs
@@ -43,7 +43,7 @@ namespace LightStep.Propagation
                         var key = entry.Key.Substring(Keys.BaggagePrefix.Length);
                         baggage.Set(key, entry.Value);
                     }
-            
+
             if (!string.IsNullOrEmpty(traceId) && !string.IsNullOrEmpty(spanId))
                 return new SpanContext(traceId, spanId, baggage);
 

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -15,7 +15,7 @@ namespace LightStep
         private readonly object _lock = new object();
         private readonly Options _options;
         private readonly IPropagator _propagator;
-
+        private readonly LightStepHttpClient _httpClient;
         private readonly ISpanRecorder _spanRecorder;
 
         /// <inheritdoc />
@@ -48,6 +48,12 @@ namespace LightStep
             _spanRecorder = spanRecorder;
             _propagator = propagator;
             _options = options;
+
+            // TODO: refactor to support changing proto
+            var url =
+                $"http://{_options.Satellite.SatelliteHost}:{_options.Satellite.SatellitePort}/{LightStepConstants.SatelliteReportPath}";
+            _httpClient = new LightStepHttpClient(url, _options);
+
             // assignment to a variable here is to suppress warnings that we're not awaiting an async method
             var reportLoop = DoReportLoop(_options.ReportPeriod);
         }
@@ -86,14 +92,11 @@ namespace LightStep
             // TODO: add retry logic so as to not drop spans on unreachable satellite
             var currentSpans = _spanRecorder.GetSpanBuffer().ToList();
             _spanRecorder.ClearSpanBuffer();
-            var url =
-                $"http://{_options.Satellite.SatelliteHost}:{_options.Satellite.SatellitePort}/{LightStepConstants.SatelliteReportPath}";
-            using (var client = new LightStepHttpClient(url, _options))
-            {
-                var data = client.Translate(currentSpans);
-                var resp = client.SendReport(data);
-                if (resp.Errors.Count > 0) Console.WriteLine($"Errors sending report to LightStep: {resp.Errors}");
-            }
+            
+            var data = _httpClient.Translate(currentSpans);
+            var resp = _httpClient.SendReport(data);
+            if (resp.Errors.Count > 0) Console.WriteLine($"Errors sending report to LightStep: {resp.Errors}");
+            
         }
 
         internal void AppendFinishedSpan(SpanData span)

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -36,6 +36,12 @@ namespace LightStep
         {
         }
 
+        /// <inheritdoc />
+        public Tracer(Options options, ISpanRecorder spanRecorder, IPropagator propagator) : this(
+            new AsyncLocalScopeManager(), propagator, options, spanRecorder)
+        {
+        }
+
         private Tracer(IScopeManager scopeManager, IPropagator propagator, Options options, ISpanRecorder spanRecorder)
         {
             ScopeManager = scopeManager;

--- a/test/LightStep.Tests/LightStep.Tests.csproj
+++ b/test/LightStep.Tests/LightStep.Tests.csproj
@@ -1,14 +1,22 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project DefaultTargets="Test" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.msbuild" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LightStep\LightStep.csproj" />
   </ItemGroup>
+  <UsingTask
+    AssemblyFile="bin\Debug\net452\xunit.runner.msbuild.net45.dll"
+    TaskName="Xunit.Runner.MSBuild.xunit"/>
+
+  <Target Name="Test">
+    <xunit Assemblies="bin\Debug\net452\LightStep.Tests.dll" Reporter="verbose" />
+  </Target>
 </Project>

--- a/test/LightStep.Tests/PropagatorTests.cs
+++ b/test/LightStep.Tests/PropagatorTests.cs
@@ -1,0 +1,58 @@
+using System;
+using LightStep.Propagation;
+using OpenTracing.Propagation;
+using Xunit;
+
+namespace LightStep.Tests
+{
+    public class PropagatorTests
+    {
+        [Fact]
+        public void PropagatorStackShouldThrowOnNullConstructor()
+        {
+            Assert.Throws<ArgumentNullException>(() => new PropagatorStack(null));
+        }
+
+        [Fact]
+        public void PropagatorStackShouldHandleEmptyConstructor()
+        {
+            var ps = new PropagatorStack(BuiltinFormats.TextMap);
+            Assert.True(ps.Propagators.Count == 0);
+            Assert.Equal(ps.Format, BuiltinFormats.TextMap);
+        }
+
+        [Fact]
+        public void PropagatorStackShouldHandleCustomFormatConstructor()
+        {
+            var customFmt = new CustomFormatter();
+            var ps = new PropagatorStack(customFmt);
+            Assert.True(ps.Propagators.Count == 0);
+            Assert.Equal(ps.Format, customFmt);
+        }
+
+        [Fact]
+        public void PropagatorStackShouldThrowOnNullPropagator()
+        {
+            var ps = new PropagatorStack(BuiltinFormats.TextMap);
+            Assert.Throws<ArgumentNullException>(() => ps.AddPropagator(null));
+        }
+
+        [Fact]
+        public void PropagatorStackShouldAddPropagator()
+        {
+            var b3Propagator = new B3Propagator();
+            var ps = new PropagatorStack(BuiltinFormats.HttpHeaders);
+            
+            Assert.Equal(ps.AddPropagator(Propagators.HttpHeadersPropagator), ps);
+            Assert.Equal(ps.AddPropagator(b3Propagator), ps);
+            Assert.Equal(2, ps.Propagators.Count);
+            Assert.Equal(ps.Propagators[0], Propagators.HttpHeadersPropagator);
+            Assert.Equal(ps.Propagators[1], b3Propagator);
+        }
+    }
+
+    internal class CustomFormatter : IFormat<ITextMap>
+    {
+        // dummy class for testing custom formatters
+    }
+}

--- a/test/LightStep.Tests/SpanTests.cs
+++ b/test/LightStep.Tests/SpanTests.cs
@@ -44,8 +44,8 @@ namespace LightStep.Tests
             var finishedSpan = recorder.GetSpanBuffer().First();
 
             // we expect there to be 2 logs and 3 tags
-            Assert.Equal(2, finishedSpan.LogData.Count);
-            Assert.Equal(3, finishedSpan.Tags.Count);
+            Assert.True(finishedSpan.LogData.Count == 2);
+            Assert.True(finishedSpan.Tags.Count == 3);
         }
 
         [Fact]
@@ -63,8 +63,8 @@ namespace LightStep.Tests
             span.Finish();
             var finishedSpan = recorder.GetSpanBuffer().First();
 
-            Assert.Equal(true, finishedSpan.Tags["boolTrueTag"]);
-            Assert.Equal(false, finishedSpan.Tags["boolFalseTag"]);
+            Assert.True((bool) finishedSpan.Tags["boolTrueTag"]);
+            Assert.False((bool) finishedSpan.Tags["boolFalseTag"]);
             Assert.Equal(0, finishedSpan.Tags["intTag"]);
             Assert.Equal("test", finishedSpan.Tags["stringTag"]);
             Assert.Equal(0.1, finishedSpan.Tags["doubleTag"]);
@@ -85,7 +85,7 @@ namespace LightStep.Tests
             span.Finish();
             var finishedSpan = recorder.GetSpanBuffer().First();
 
-            Assert.Equal(true, finishedSpan.Tags["testBoolTag"]);
+            Assert.True((bool) finishedSpan.Tags["testBoolTag"]);
             Assert.Equal(1, finishedSpan.Tags["testIntTag"]);
             Assert.Equal("test", finishedSpan.Tags["testStringTag"]);
             Assert.Equal("string", finishedSpan.Tags["testIntOrStringTagAsString"]);
@@ -102,8 +102,14 @@ namespace LightStep.Tests
             span.Finish();
 
             var finishedSpan = recorder.GetSpanBuffer().First();
-
-            Assert.True(finishedSpan.LogData.Any(item => item.Fields.Any(x => x.Value.Equals("hello world!"))));
+            // project the sequence of logdata into an array with one item, the aforementioned log message
+            var finishedSpanLogData = finishedSpan.LogData.Select(
+                item => item.Fields.First(
+                    f => f.Value.Equals("hello world!")
+                ).Value).ToArray()[0];
+            
+            Assert.Equal("hello world!", (string) finishedSpanLogData);
+            
         }
     }
 }

--- a/test/LightStep.Tests/SpanTests.cs
+++ b/test/LightStep.Tests/SpanTests.cs
@@ -107,9 +107,8 @@ namespace LightStep.Tests
                 item => item.Fields.First(
                     f => f.Value.Equals("hello world!")
                 ).Value).ToArray()[0];
-            
+
             Assert.Equal("hello world!", (string) finishedSpanLogData);
-            
         }
     }
 }


### PR DESCRIPTION
This fixes #10.

Major changes:
* Added B3 header propagator.
* Added `PropagatorStack` concept from the Java lib; Tracers can now be initialized with a stack of propagators that will inject/extract through multiple propagators.

Minor changes:
* Changed target framework versions from `net452;netstandard2.0` to `net45;netstandard2.0`. We can drop down to base 4.5 to increase the amount of runtimes supported.

Bugs fixed:
* Propagators would throw on mismatched formats; they now simply return null.