### PR TITLE
Allow switching of HTTP2/1.1 in options

### DIFF
--- a/src/LightStep/Collector/LightStepHttpClient.cs
+++ b/src/LightStep/Collector/LightStepHttpClient.cs
@@ -41,7 +41,7 @@ namespace LightStep.Collector
 
             var request = new HttpRequestMessage(HttpMethod.Post, _url)
             {
-                Version = new Version(2, 0),
+                Version = _options.UseHttp2 ? new Version(1, 1) : new Version(2, 0),
                 Content = new ByteArrayContent(report.ToByteArray())
             };
 

--- a/src/LightStep/Collector/LightStepHttpClient.cs
+++ b/src/LightStep/Collector/LightStepHttpClient.cs
@@ -41,7 +41,7 @@ namespace LightStep.Collector
 
             var request = new HttpRequestMessage(HttpMethod.Post, _url)
             {
-                Version = _options.UseHttp2 ? new Version(1, 1) : new Version(2, 0),
+                Version = _options.UseHttp2 ? new Version(2, 0) : new Version(1, 1),
                 Content = new ByteArrayContent(report.ToByteArray())
             };
 

--- a/src/LightStep/Options.cs
+++ b/src/LightStep/Options.cs
@@ -29,12 +29,18 @@ namespace LightStep
             ReportTimeout = TimeSpan.FromSeconds(30);
             AccessToken = token;
             Satellite = satelliteOptions;
+            UseHttp2 = true;
         }
 
         /// <summary>
         ///     API key for a LightStep project.
         /// </summary>
         public string AccessToken { get; set; }
+        
+        /// <summary>
+        ///     True if the satellite connection should use HTTP/2, false otherwise.
+        /// </summary>
+        public bool UseHttp2;
 
         /// <summary>
         ///     LightStep Satellite endpoint configuration.


### PR DESCRIPTION
This PR simply exposes a new public property on the `Options` object that allows users to switch between HTTP/2 and HTTP/1.1 for the `LightStepHttpClient`.