### PR TITLE
Fix header keys

### DIFF
--- a/src/LightStep/Propagation/Keys.cs
+++ b/src/LightStep/Propagation/Keys.cs
@@ -8,7 +8,7 @@
         /// <summary>
         ///     OpenTracing Baggage Prefix
         /// </summary>
-        public const string BaggagePrefix = "ot-baggage";
+        public const string BaggagePrefix = "ot-baggage-";
 
         /// <summary>
         ///     OpenTracing TraceId Prefix

--- a/src/LightStep/Propagation/Keys.cs
+++ b/src/LightStep/Propagation/Keys.cs
@@ -8,16 +8,21 @@
         /// <summary>
         ///     OpenTracing Baggage Prefix
         /// </summary>
-        public const string BaggagePrefix = "ot-bg-";
+        public const string BaggagePrefix = "ot-baggage";
 
         /// <summary>
         ///     OpenTracing TraceId Prefix
         /// </summary>
-        public const string TraceId = "ot-traceid";
+        public const string TraceId = "ot-tracer-traceid";
 
         /// <summary>
         ///     OpenTracing SpanId Prefix
         /// </summary>
-        public const string SpanId = "ot-spanid";
+        public const string SpanId = "ot-tracer-spanid";
+
+        /// <summary>
+        ///     OpenTracing Sampled Prefix
+        /// </summary>
+        public const string SampledId = "ot-tracer-sampled";
     }
 }

--- a/src/LightStep/Propagation/TextMapPropagator.cs
+++ b/src/LightStep/Propagation/TextMapPropagator.cs
@@ -15,6 +15,7 @@ namespace LightStep.Propagation
 
                 text.Set(Keys.SpanId, context.SpanId);
                 text.Set(Keys.TraceId, context.TraceId);
+                text.Set(Keys.SampledId, "true");
             }
             else
             {

--- a/test/LightStep.Tests/PropagatorTests.cs
+++ b/test/LightStep.Tests/PropagatorTests.cs
@@ -34,9 +34,9 @@ namespace LightStep.Tests
 
             tracer.Inject(span.Context, BuiltinFormats.HttpHeaders, new TextMapInjectAdapter(data));
 
-            Assert.Equal(traceId, data["ot-traceid"]);
+            Assert.Equal(traceId, data["ot-tracer-traceid"]);
             Assert.Equal(hexTraceId, data["X-B3-TraceId"]);
-            Assert.Equal(spanId, data["ot-spanid"]);
+            Assert.Equal(spanId, data["ot-tracer-spanid"]);
             Assert.Equal(hexSpanId, data["X-B3-SpanId"]);
 
             span.Finish();

--- a/test/LightStep.Tests/TracerTests.cs
+++ b/test/LightStep.Tests/TracerTests.cs
@@ -34,8 +34,8 @@ namespace LightStep.Tests
             var spanId = new Random().NextUInt64().ToString();
             var data = new Dictionary<string, string>
             {
-                {"ot-traceid", traceId},
-                {"ot-spanid", spanId}
+                {"ot-tracer-traceid", traceId},
+                {"ot-tracer-spanid", spanId}
             };
 
             var spanContext = tracer.Extract(BuiltinFormats.TextMap, new TextMapExtractAdapter(data));
@@ -67,8 +67,8 @@ namespace LightStep.Tests
 
             tracer.Inject(span.Context, BuiltinFormats.TextMap, new TextMapInjectAdapter(data));
 
-            Assert.Equal(traceId, data["ot-traceid"]);
-            Assert.Equal(spanId, data["ot-spanid"]);
+            Assert.Equal(traceId, data["ot-tracer-traceid"]);
+            Assert.Equal(spanId, data["ot-tracer-spanid"]);
         }
 
         [Fact]


### PR DESCRIPTION
The OT header keys weren't correct; This modifies them to comport with the rest of the LS tracers.