### PR TITLE
Convert ticks to microseconds

### DIFF
--- a/src/LightStep/Collector/ProtoConverter.cs
+++ b/src/LightStep/Collector/ProtoConverter.cs
@@ -25,6 +25,7 @@ namespace LightStep.Collector
     /// <inheritdoc />
     public partial class Span
     {
+        const long TicksPerMicrosecond = 10;
         /// <summary>
         ///     Converts a <see cref="SpanData" /> to a <see cref="Span" />
         /// </summary>
@@ -32,7 +33,8 @@ namespace LightStep.Collector
         /// <returns>Proto Span</returns>
         public Span MakeSpanFromSpanData(SpanData span)
         {
-            DurationMicros = Convert.ToUInt64(span.Duration.Ticks);
+            // ticks are not equal to microseconds, so convert
+            DurationMicros = Convert.ToUInt64(span.Duration.Ticks / TicksPerMicrosecond);
             OperationName = span.OperationName;
             SpanContext = new SpanContext().MakeSpanContextFromOtSpanContext(span.Context);
             StartTimestamp = Timestamp.FromDateTime(span.StartTimestamp.UtcDateTime);


### PR DESCRIPTION
LightStep expects the span duration to be in microseconds and not ticks. When I wrote the converter from SpanData to protobuf, I forgot to check and make sure the units were the same, so we were passing ticks into `DurationMicros`. This has the unfortunate side effect of not being terribly noticeable until you have longer duration spans, as the formula to convert ticks into micros is `Ticks / 10,000`... so for sufficiently small amounts of ticks, things "look" right.