### PR TITLE
Increase randomness of ID generation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,5 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+examples/LightStep.CSharpAspectTestApp/App.config

--- a/LightStep.sln
+++ b/LightStep.sln
@@ -1,19 +1,24 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightStepTracer", ".\src\LightStep\LightStep.csproj", "{E5F75D2A-B882-46BB-A173-0F77E46498E2}"
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2016
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LightStep", "src\LightStep\LightStep.csproj", "{E5F75D2A-B882-46BB-A173-0F77E46498E2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{BE409569-9FA2-4741-8ABF-327D56E6598E}"
-ProjectSection(SolutionItems) = preProject
-	README.md = README.md
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{1359ACF9-43F2-4E09-94FD-32EB2C6239BA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightStep.Tracer.Tests", "test\LightStep.Tests\LightStep.Tests.csproj", "{2DB2D4A0-64AB-4C5B-ACB5-0C2EB76D756C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LightStep.Tests", "test\LightStep.Tests\LightStep.Tests.csproj", "{2DB2D4A0-64AB-4C5B-ACB5-0C2EB76D756C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightStep.TestApp", "examples\LightStep.CSharpTestApp\LightStep.CSharpTestApp.csproj", "{65A11CA6-E7E9-43B6-A36D-6B54EA9BD758}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LightStep.CSharpTestApp", "examples\LightStep.CSharpTestApp\LightStep.CSharpTestApp.csproj", "{65A11CA6-E7E9-43B6-A36D-6B54EA9BD758}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{113EDBB5-081F-4581-B687-9293B4D74312}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightStep.CSharpAspectTestApp", "examples\LightStep.CSharpAspectTestApp\LightStep.CSharpAspectTestApp.csproj", "{1B83F7CF-E2AA-4A81-9C0B-2DA716D5C982}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,10 +38,21 @@ Global
 		{65A11CA6-E7E9-43B6-A36D-6B54EA9BD758}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{65A11CA6-E7E9-43B6-A36D-6B54EA9BD758}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{65A11CA6-E7E9-43B6-A36D-6B54EA9BD758}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B83F7CF-E2AA-4A81-9C0B-2DA716D5C982}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B83F7CF-E2AA-4A81-9C0B-2DA716D5C982}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B83F7CF-E2AA-4A81-9C0B-2DA716D5C982}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B83F7CF-E2AA-4A81-9C0B-2DA716D5C982}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{E5F75D2A-B882-46BB-A173-0F77E46498E2} = {BE409569-9FA2-4741-8ABF-327D56E6598E}
 		{2DB2D4A0-64AB-4C5B-ACB5-0C2EB76D756C} = {1359ACF9-43F2-4E09-94FD-32EB2C6239BA}
 		{65A11CA6-E7E9-43B6-A36D-6B54EA9BD758} = {113EDBB5-081F-4581-B687-9293B4D74312}
+		{1B83F7CF-E2AA-4A81-9C0B-2DA716D5C982} = {113EDBB5-081F-4581-B687-9293B4D74312}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0890664C-9CE4-4960-90A4-AD6565C970E3}
 	EndGlobalSection
 EndGlobal

--- a/examples/LightStep.CSharpAspectTestApp/App.config
+++ b/examples/LightStep.CSharpAspectTestApp/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    </startup>
+</configuration>

--- a/examples/LightStep.CSharpAspectTestApp/App.config
+++ b/examples/LightStep.CSharpAspectTestApp/App.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup>
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
-    </startup>
-</configuration>

--- a/examples/LightStep.CSharpAspectTestApp/Aspects/Traceable.cs
+++ b/examples/LightStep.CSharpAspectTestApp/Aspects/Traceable.cs
@@ -12,40 +12,33 @@ namespace LightStep.CSharpAspectTestApp.Aspects
     [PSerializable]
     public sealed class Traceable : OnMethodBoundaryAspect
     {
-        OpenTracing.IScope scope;
         public override void OnEntry(MethodExecutionArgs args)
         {
-            Console.WriteLine($"method {args.Method.Name} is being called");
-            scope = GlobalTracer.Instance.BuildSpan(args.Method.Name).StartActive();
+            // when we enter a method, build a new span and mark it as active
+            var scope = GlobalTracer.Instance.BuildSpan(args.Method.Name).StartActive();
             Console.WriteLine($"new span id {scope.Span.Context.SpanId}");
         }
 
         public override void OnSuccess(MethodExecutionArgs args)
         {
+            // only finish a span in OnExit, as it gets called as a finalizer
             Console.WriteLine("The {0} method executed successfully.", args.Method.Name);
         }
 
         public override void OnExit(MethodExecutionArgs args)
         {
+            // when a method exits (either successfully or unsuccessfully), dispose of the scope to free it on our singleton tracer
+            var scope = GlobalTracer.Instance.ScopeManager.Active;
             Console.WriteLine($"finishing span id {scope.Span.Context.SpanId}");
-            scope.Span.Finish();
+            scope.Dispose();
         }
 
         public override void OnException(MethodExecutionArgs args)
         {
-            scope.Span.Log(args.Exception.StackTrace);
+            // if an exception occurs, get the active scope then set the exception log, add tags, whatever.
+            var scope = GlobalTracer.Instance.ScopeManager.Active;
             Console.WriteLine("An exception was thrown in {0}.", args.Method.Name);
-        }
-        /**
-        public object CreateInstance(AdviceArgs adviceArgs)
-        {
-            return this.MemberwiseClone();
-        }
-
-        public void RuntimeInitializeInstance()
-        {
-            
-        }
-    */
+            scope.Span.Log(args.Exception.StackTrace);         
+        }  
     }
 }

--- a/examples/LightStep.CSharpAspectTestApp/Aspects/Traceable.cs
+++ b/examples/LightStep.CSharpAspectTestApp/Aspects/Traceable.cs
@@ -1,0 +1,51 @@
+﻿using OpenTracing.Util;
+using PostSharp.Aspects;
+using PostSharp.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LightStep.CSharpAspectTestApp.Aspects
+{
+    [PSerializable]
+    public sealed class Traceable : OnMethodBoundaryAspect
+    {
+        OpenTracing.IScope scope;
+        public override void OnEntry(MethodExecutionArgs args)
+        {
+            Console.WriteLine($"method {args.Method.Name} is being called");
+            scope = GlobalTracer.Instance.BuildSpan(args.Method.Name).StartActive();
+            Console.WriteLine($"new span id {scope.Span.Context.SpanId}");
+        }
+
+        public override void OnSuccess(MethodExecutionArgs args)
+        {
+            Console.WriteLine("The {0} method executed successfully.", args.Method.Name);
+        }
+
+        public override void OnExit(MethodExecutionArgs args)
+        {
+            Console.WriteLine($"finishing span id {scope.Span.Context.SpanId}");
+            scope.Span.Finish();
+        }
+
+        public override void OnException(MethodExecutionArgs args)
+        {
+            scope.Span.Log(args.Exception.StackTrace);
+            Console.WriteLine("An exception was thrown in {0}.", args.Method.Name);
+        }
+        /**
+        public object CreateInstance(AdviceArgs adviceArgs)
+        {
+            return this.MemberwiseClone();
+        }
+
+        public void RuntimeInitializeInstance()
+        {
+            
+        }
+    */
+    }
+}

--- a/examples/LightStep.CSharpAspectTestApp/HttpWorker.cs
+++ b/examples/LightStep.CSharpAspectTestApp/HttpWorker.cs
@@ -1,0 +1,40 @@
+﻿using LightStep.CSharpAspectTestApp.Aspects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LightStep.CSharpAspectTestApp
+{
+    class HttpWorker
+    {
+        private HttpClient httpClient;
+
+        public HttpWorker()
+        {
+            httpClient = new HttpClient();
+        }
+        
+        [Traceable]
+        public async void Get(string url)
+        {
+            var content = await GetString(url);
+            Write(content);
+        }
+
+        [Traceable]
+        public static void Write(string content)
+        {
+            Console.WriteLine(content);
+        }
+
+        [Traceable]
+        public async Task<string> GetString(string url)
+        {
+            var content = await httpClient.GetStringAsync(url);
+            return content;
+        }
+    }
+}

--- a/examples/LightStep.CSharpAspectTestApp/LightStep.CSharpAspectTestApp.csproj
+++ b/examples/LightStep.CSharpAspectTestApp/LightStep.CSharpAspectTestApp.csproj
@@ -1,0 +1,80 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\PostSharp.6.0.27\build\PostSharp.props" Condition="Exists('..\..\packages\PostSharp.6.0.27\build\PostSharp.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1B83F7CF-E2AA-4A81-9C0B-2DA716D5C982}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>LightStep.CSharpAspectTestApp</RootNamespace>
+    <AssemblyName>LightStep.CSharpAspectTestApp</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="OpenTracing, Version=0.12.0.0, Culture=neutral, PublicKeyToken=61503406977abdaf, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OpenTracing.0.12.0\lib\net45\OpenTracing.dll</HintPath>
+    </Reference>
+    <Reference Include="PostSharp, Version=6.0.27.0, Culture=neutral, PublicKeyToken=b13fd38b8f9c99d7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PostSharp.Redist.6.0.27\lib\net45\PostSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Aspects\Traceable.cs" />
+    <Compile Include="HttpWorker.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LightStep\LightStep.csproj">
+      <Project>{e5f75d2a-b882-46bb-a173-0f77e46498e2}</Project>
+      <Name>LightStep</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\PostSharp.6.0.27\build\PostSharp.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\PostSharp.6.0.27\build\PostSharp.props'))" />
+    <Error Condition="!Exists('..\..\packages\PostSharp.6.0.27\build\PostSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\PostSharp.6.0.27\build\PostSharp.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\PostSharp.6.0.27\build\PostSharp.targets" Condition="Exists('..\..\packages\PostSharp.6.0.27\build\PostSharp.targets')" />
+</Project>

--- a/examples/LightStep.CSharpAspectTestApp/LightStep.CSharpAspectTestApp.csproj
+++ b/examples/LightStep.CSharpAspectTestApp/LightStep.CSharpAspectTestApp.csproj
@@ -42,6 +42,7 @@
       <HintPath>..\..\packages\PostSharp.Redist.6.0.27\lib\net45\PostSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Xml.Linq" />

--- a/examples/LightStep.CSharpAspectTestApp/Program.cs
+++ b/examples/LightStep.CSharpAspectTestApp/Program.cs
@@ -13,31 +13,27 @@ namespace LightStep.CSharpAspectTestApp
     {
         static void Main(string[] args)
         {
+            // create your tracer options, initialize it, assign it to the GlobalTracer
             var lsKey = ConfigurationManager.AppSettings["lsKey"];
             var lsSettings = new SatelliteOptions("collector.lightstep.com");
             var lsOptions = new Options(lsKey, lsSettings);
             lsOptions.UseHttp2 = false;
-            lsOptions.ReportPeriod = new TimeSpan(0, 0, 10);
             var tracer = new Tracer(lsOptions);
             
             GlobalTracer.Register(tracer);
 
-            // The code provided will print ‘Hello World’ to the console.
-            // Press Ctrl+F5 (or go to Debug > Start Without Debugging) to run your app.
+            // do some work in parallel, this work also includes awaited calls
+            Parallel.For(1, 100, i => DoThing(i));
 
-            DoThing();
-            
-            //tracer.Flush();
+            // block until you enter a key
             Console.ReadKey();
-
-            // Go to http://aka.ms/dotnet-get-started-console to continue learning how to build a console app! 
         }
 
         [Traceable]
-        static void DoThing()
+        static void DoThing(int idx)
         {
             var client = new HttpWorker();
-            client.Get("https://jsonplaceholder.typicode.com/todos/1");
+            client.Get($"https://jsonplaceholder.typicode.com/todos/{idx}");
         }
 
     }

--- a/examples/LightStep.CSharpAspectTestApp/Program.cs
+++ b/examples/LightStep.CSharpAspectTestApp/Program.cs
@@ -1,5 +1,7 @@
+using LightStep.CSharpAspectTestApp.Aspects;
 using OpenTracing.Util;
 using System;
+using System.Configuration;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,7 +13,7 @@ namespace LightStep.CSharpAspectTestApp
     {
         static void Main(string[] args)
         {
-            var lsKey = "7462e3fc8a93e171b1524cec623700f5";
+            var lsKey = ConfigurationManager.AppSettings["lsKey"];
             var lsSettings = new SatelliteOptions("collector.lightstep.com");
             var lsOptions = new Options(lsKey, lsSettings);
             lsOptions.UseHttp2 = false;
@@ -22,20 +24,21 @@ namespace LightStep.CSharpAspectTestApp
 
             // The code provided will print ‘Hello World’ to the console.
             // Press Ctrl+F5 (or go to Debug > Start Without Debugging) to run your app.
-            Console.WriteLine("Hello World!");
-            using (var scope = tracer.BuildSpan("main").StartActive())
-            {
-                Console.WriteLine(scope.Span.Context.SpanId);
-                var client = new HttpWorker();
-                client.Get("https://jsonplaceholder.typicode.com/todos/1");
-            }
 
+            DoThing();
+            
             //tracer.Flush();
             Console.ReadKey();
 
             // Go to http://aka.ms/dotnet-get-started-console to continue learning how to build a console app! 
         }
 
+        [Traceable]
+        static void DoThing()
+        {
+            var client = new HttpWorker();
+            client.Get("https://jsonplaceholder.typicode.com/todos/1");
+        }
 
     }
 }

--- a/examples/LightStep.CSharpAspectTestApp/Program.cs
+++ b/examples/LightStep.CSharpAspectTestApp/Program.cs
@@ -1,0 +1,41 @@
+using OpenTracing.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LightStep.CSharpAspectTestApp
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var lsKey = "7462e3fc8a93e171b1524cec623700f5";
+            var lsSettings = new SatelliteOptions("collector.lightstep.com");
+            var lsOptions = new Options(lsKey, lsSettings);
+            lsOptions.UseHttp2 = false;
+            lsOptions.ReportPeriod = new TimeSpan(0, 0, 10);
+            var tracer = new Tracer(lsOptions);
+            
+            GlobalTracer.Register(tracer);
+
+            // The code provided will print ‘Hello World’ to the console.
+            // Press Ctrl+F5 (or go to Debug > Start Without Debugging) to run your app.
+            Console.WriteLine("Hello World!");
+            using (var scope = tracer.BuildSpan("main").StartActive())
+            {
+                Console.WriteLine(scope.Span.Context.SpanId);
+                var client = new HttpWorker();
+                client.Get("https://jsonplaceholder.typicode.com/todos/1");
+            }
+
+            //tracer.Flush();
+            Console.ReadKey();
+
+            // Go to http://aka.ms/dotnet-get-started-console to continue learning how to build a console app! 
+        }
+
+
+    }
+}

--- a/examples/LightStep.CSharpAspectTestApp/Properties/AssemblyInfo.cs
+++ b/examples/LightStep.CSharpAspectTestApp/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("LightStep.CSharpAspectTestApp")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("LightStep.CSharpAspectTestApp")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1b83f7cf-e2aa-4a81-9c0b-2da716d5c982")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/examples/LightStep.CSharpAspectTestApp/packages.config
+++ b/examples/LightStep.CSharpAspectTestApp/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="OpenTracing" version="0.12.0" targetFramework="net461" />
+  <package id="PostSharp" version="6.0.27" targetFramework="net461" />
+  <package id="PostSharp.Redist" version="6.0.27" targetFramework="net461" />
+</packages>

--- a/src/LightStep/Span.cs
+++ b/src/LightStep/Span.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using OpenTracing;
 using OpenTracing.Tag;
 
@@ -187,7 +188,10 @@ namespace LightStep
 
         private static string GetRandomId()
         {
-            return new Random().NextUInt64().ToString();
+            var provider = new RNGCryptoServiceProvider();
+            var buffer = new byte[64];
+            provider.GetBytes(buffer);
+            return BitConverter.ToUInt64(buffer, 0).ToString();
         }
 
         private static SpanContext FindPreferredParentRef(IList<Reference> references)


### PR DESCRIPTION
There's 2 major parts to this PR -

1. An enhancement to `GetRandomId` in the `Span` class. The previous behavior could lead to a case where multiple spans created at the same time (for example, during high #'s of requests during async calls) would have colliding Span ID's in the same trace. These collisions lead to display errors and orphaned spans in the LightStep UI.

2. An example application using PostSharp Aspects to demonstrate using interceptors to trace methods.