### PR TITLE
Fix Span Flushing, HttpClient getting into bad state, nulls in tags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ _v0.0.8_
 - Addresses an issue where the `LightStepHttpClient` would stop sending spans if it received a non-success status code from the LightStep Satellite.
 - *Change* The `LightStepHttpClient` will prefer HTTP/1.1 to HTTP/2. Change ths using `Options.UseHttp2`.
 - The NuGet package now includes PDB files.
+- The `Options` object now exposes a property `Run` that will determine if the Tracer should flush spans.
 
 _v0.0.7_
 - When instantiating a `Tracer`, you can now pass additional tags in `Options` to apply to all spans. You can also override existing LightStep span tags.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+_v0.0.8_
+- Addresses an issue where the `Tracer` would not `Flush` regularly.
+- Addresses an issue where tags with null values would cause the tracer to not report spans.
+- Addresses an issue where the `LightStepHttpClient` would stop sending spans if it received a non-success status code from the LightStep Satellite.
+- *Change* The `LightStepHttpClient` will prefer HTTP/1.1 to HTTP/2. Change ths using `Options.UseHttp2`.
+- The NuGet package now includes PDB files.
+
+_v0.0.7_
+- When instantiating a `Tracer`, you can now pass additional tags in `Options` to apply to all spans. You can also override existing LightStep span tags.
+
 _v0.0.6_
 - Addresses an issue where the signing key wasn't actually being used to sign the assembly.
 - Removes unneded `net452` target framework from LightStep project.

--- a/src/LightStep/Collector/LightStepHttpClient.cs
+++ b/src/LightStep/Collector/LightStepHttpClient.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading.Tasks;
 using Google.Protobuf;
 
 namespace LightStep.Collector
@@ -34,14 +36,14 @@ namespace LightStep.Collector
         /// </summary>
         /// <param name="report">An <see cref="ReportRequest" /></param>
         /// <returns>A <see cref="ReportResponse" />. This is usually not very interesting.</returns>
-        public ReportResponse SendReport(ReportRequest report)
+        public async Task<ReportResponse> SendReport(ReportRequest report)
         {
             // force net45 to attempt tls12 first and fallback appropriately
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
             
             _client.DefaultRequestHeaders.Accept.Add(
                 new MediaTypeWithQualityHeaderValue("application/octet-stream"));
-
+            Console.WriteLine($"sending {report.Spans.Count} to satellite");
             var request = new HttpRequestMessage(HttpMethod.Post, _url)
             {
                 Version = _options.UseHttp2 ? new Version(2, 0) : new Version(1, 1),
@@ -50,9 +52,21 @@ namespace LightStep.Collector
 
             request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
 
-            var response = _client.SendAsync(request).Result;
-            var responseData = response.Content.ReadAsStreamAsync().Result;
-            return ReportResponse.Parser.ParseFrom(responseData);
+            ReportResponse responseValue = new ReportResponse();
+            
+            try
+            {
+                var response = await _client.SendAsync(request);
+                response.EnsureSuccessStatusCode();
+                var responseData = await response.Content.ReadAsStreamAsync();
+                responseValue = ReportResponse.Parser.ParseFrom(responseData);
+            }
+            catch (HttpRequestException ex)
+            {
+                Console.WriteLine(ex);
+            }
+
+            return responseValue;
         }
 
         /// <summary>

--- a/src/LightStep/Collector/ProtoConverter.cs
+++ b/src/LightStep/Collector/ProtoConverter.cs
@@ -120,6 +120,11 @@ namespace LightStep.Collector
         public KeyValue MakeKeyValueFromKvp(KeyValuePair<string, object> input)
         {
             Key = input.Key;
+            if (input.Value == null)
+            {
+                StringValue = "";
+                return this;
+            }
             if (input.Value.GetType().IsNumericDataType()) DoubleValue = Convert.ToDouble(input.Value);
             if (input.Value.GetType().IsBooleanDataType())
                 BoolValue = Convert.ToBoolean(input.Value);

--- a/src/LightStep/ISpanRecorder.cs
+++ b/src/LightStep/ISpanRecorder.cs
@@ -17,7 +17,7 @@ namespace LightStep
         ///     Gets the current record of spans.
         /// </summary>
         /// <returns></returns>
-        IEnumerable<SpanData> GetSpanBuffer();
+        List<SpanData> GetSpanBuffer();
 
         /// <summary>
         ///     Clears the span record.

--- a/src/LightStep/LightStep.csproj
+++ b/src/LightStep/LightStep.csproj
@@ -32,7 +32,7 @@
       
   <PropertyGroup>
       <Authors>Austin Parker</Authors>
-      <PackageVersion>0.0.7-alpha-$(CIRCLE_BUILD_NUM)</PackageVersion>
+      <PackageVersion>0.0.8-alpha-$(CIRCLE_BUILD_NUM)</PackageVersion>
       <Company>LightStep</Company>
       <NeutralLanguage>en-US</NeutralLanguage>
       <AssemblyTitle>LightStep</AssemblyTitle>
@@ -56,5 +56,6 @@
       <DelaySign>false</DelaySign>
       <AssemblyOriginatorKeyFile>tracerSign.snk</AssemblyOriginatorKeyFile>
       <_UseRoslynPublicSignHack>false</_UseRoslynPublicSignHack>
+      <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 </Project>

--- a/src/LightStep/LightStepSpanRecorder.cs
+++ b/src/LightStep/LightStepSpanRecorder.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace LightStep
 {
@@ -10,19 +12,34 @@ namespace LightStep
         /// <inheritdoc />
         public void RecordSpan(SpanData span)
         {
-            Spans.Add(span);
+            lock (Spans)
+            {
+                Spans.Add(span);    
+            }
+            
         }
 
         /// <inheritdoc />
-        public IEnumerable<SpanData> GetSpanBuffer()
+        public List<SpanData> GetSpanBuffer()
         {
-            return Spans;
+            lock (Spans)
+            {
+                Console.WriteLine($"copying {Spans.Count} to new buffer");
+                var currentSpans = Spans.ToList();
+                Spans.Clear();
+                return currentSpans;
+            }
+            
         }
 
         /// <inheritdoc />
         public void ClearSpanBuffer()
         {
-            Spans.Clear();
+            lock (Spans)
+            {
+                Spans.Clear();    
+            }
+            
         }
     }
 }

--- a/src/LightStep/LightStepSpanRecorder.cs
+++ b/src/LightStep/LightStepSpanRecorder.cs
@@ -24,7 +24,6 @@ namespace LightStep
         {
             lock (Spans)
             {
-                Console.WriteLine($"copying {Spans.Count} to new buffer");
                 var currentSpans = Spans.ToList();
                 Spans.Clear();
                 return currentSpans;

--- a/src/LightStep/Options.cs
+++ b/src/LightStep/Options.cs
@@ -40,7 +40,7 @@ namespace LightStep
             ReportTimeout = TimeSpan.FromSeconds(30);
             AccessToken = token;
             Satellite = satelliteOptions;
-            UseHttp2 = true;
+            UseHttp2 = false;
         }
 
         /// <summary>

--- a/src/LightStep/Options.cs
+++ b/src/LightStep/Options.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿using Microsoft.Win32;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.Versioning;
 
 namespace LightStep
 {
@@ -125,7 +127,13 @@ namespace LightStep
 
         private static string GetPlatformVersion()
         {
-            return Environment.Version.ToString();
+#if NET45
+            return AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName;
+#elif NETSTANDARD2_0
+            return Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
+#else
+            return "Unknown Framework Version";
+#endif
         }
 
 

--- a/src/LightStep/Options.cs
+++ b/src/LightStep/Options.cs
@@ -41,13 +41,19 @@ namespace LightStep
             AccessToken = token;
             Satellite = satelliteOptions;
             UseHttp2 = false;
+            Run = true;
         }
 
         /// <summary>
         ///     API key for a LightStep project.
         /// </summary>
         public string AccessToken { get; set; }
-        
+
+        /// <summary>
+        /// If true, tracer will start reporting
+        /// </summary>
+        /// 
+        public bool Run { get; set; }
         /// <summary>
         ///     True if the satellite connection should use HTTP/2, false otherwise.
         /// </summary>

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using LightStep.Collector;
 using LightStep.Propagation;
@@ -17,6 +19,7 @@ namespace LightStep
         private readonly IPropagator _propagator;
         private readonly LightStepHttpClient _httpClient;
         private readonly ISpanRecorder _spanRecorder;
+        private readonly Timer _reportLoop;
 
         /// <inheritdoc />
         public Tracer(Options options) : this(new AsyncLocalScopeManager(), Propagators.TextMap, options,
@@ -56,7 +59,8 @@ namespace LightStep
             _httpClient = new LightStepHttpClient(url, _options);
 
             // assignment to a variable here is to suppress warnings that we're not awaiting an async method
-            var reportLoop = DoReportLoop(_options.ReportPeriod);
+            _reportLoop = new Timer(e => Flush(), null, TimeSpan.Zero, _options.ReportPeriod);
+            
         }
 
         /// <inheritdoc />
@@ -87,17 +91,18 @@ namespace LightStep
         ///     Transmits the current contents of the span buffer to the LightStep Satellite.
         ///     Note that this creates a copy of the current spans and clears the span buffer!
         /// </summary>
-        public void Flush()
+        public async void Flush()
         {
             // save current spans and clear the buffer
             // TODO: add retry logic so as to not drop spans on unreachable satellite
-            var currentSpans = _spanRecorder.GetSpanBuffer().ToList();
-            _spanRecorder.ClearSpanBuffer();
-            
+            List<SpanData> currentSpans = new List<SpanData>();
+            lock (_lock)
+            {
+                currentSpans = _spanRecorder.GetSpanBuffer();   
+            }  
             var data = _httpClient.Translate(currentSpans);
-            var resp = _httpClient.SendReport(data);
+            var resp = await _httpClient.SendReport(data);
             if (resp.Errors.Count > 0) Console.WriteLine($"Errors sending report to LightStep: {resp.Errors}");
-            
         }
 
         internal void AppendFinishedSpan(SpanData span)
@@ -105,15 +110,6 @@ namespace LightStep
             lock (_lock)
             {
                 _spanRecorder.RecordSpan(span);
-            }
-        }
-
-        private async Task DoReportLoop(TimeSpan reportingPeriod)
-        {
-            while (true)
-            {
-                Flush();
-                await Task.Delay(reportingPeriod);
             }
         }
     }

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -93,16 +93,19 @@ namespace LightStep
         /// </summary>
         public async void Flush()
         {
-            // save current spans and clear the buffer
-            // TODO: add retry logic so as to not drop spans on unreachable satellite
-            List<SpanData> currentSpans = new List<SpanData>();
-            lock (_lock)
+            if (_options.Run)
             {
-                currentSpans = _spanRecorder.GetSpanBuffer();   
-            }  
-            var data = _httpClient.Translate(currentSpans);
-            var resp = await _httpClient.SendReport(data);
-            if (resp.Errors.Count > 0) Console.WriteLine($"Errors sending report to LightStep: {resp.Errors}");
+                // save current spans and clear the buffer
+                // TODO: add retry logic so as to not drop spans on unreachable satellite
+                List<SpanData> currentSpans = new List<SpanData>();
+                lock (_lock)
+                {
+                    currentSpans = _spanRecorder.GetSpanBuffer();
+                }
+                var data = _httpClient.Translate(currentSpans);
+                var resp = await _httpClient.SendReport(data);
+                if (resp.Errors.Count > 0) Console.WriteLine($"Errors sending report to LightStep: {resp.Errors}");
+            }
         }
 
         internal void AppendFinishedSpan(SpanData span)

--- a/test/LightStep.Tests/PropagatorTests.cs
+++ b/test/LightStep.Tests/PropagatorTests.cs
@@ -19,6 +19,7 @@ namespace LightStep.Tests
             var sr = new SimpleMockRecorder();
             var satOpts = new SatelliteOptions("localhost", 80, true);
             var tracerOpts = new Options("TEST", satOpts);
+            tracerOpts.Run = false;
 
             var tracer = new Tracer(tracerOpts, sr, ps);
 

--- a/test/LightStep.Tests/SimpleMockRecorder.cs
+++ b/test/LightStep.Tests/SimpleMockRecorder.cs
@@ -11,7 +11,7 @@ namespace LightStep.Tests
             Spans.Add(span);
         }
 
-        public IEnumerable<SpanData> GetSpanBuffer()
+        public List<SpanData> GetSpanBuffer()
         {
             return Spans;
         }

--- a/test/LightStep.Tests/SpanTests.cs
+++ b/test/LightStep.Tests/SpanTests.cs
@@ -14,7 +14,7 @@ namespace LightStep.Tests
             var spanRecorder = recorder ?? new SimpleMockRecorder();
             var satelliteOptions = new SatelliteOptions("localhost", 80, true);
             var tracerOptions = new Options("TEST", satelliteOptions);
-
+            tracerOptions.Run = false;
             return new Tracer(tracerOptions, spanRecorder);
         }
 

--- a/test/LightStep.Tests/TracerTests.cs
+++ b/test/LightStep.Tests/TracerTests.cs
@@ -13,6 +13,7 @@ namespace LightStep.Tests
             var spanRecorder = recorder ?? new SimpleMockRecorder();
             var satelliteOptions = new SatelliteOptions("localhost", 80, true);
             var tracerOptions = new Options("TEST", satelliteOptions);
+            tracerOptions.Run = false;
 
             return new Tracer(tracerOptions, spanRecorder);
         }


### PR DESCRIPTION
Multiple fixes in this PR -
* Spans would not get automatically flushed as part of the reporting loop; This addresses that by properly creating a timed thread.
* After some time, the Tracer would receive `HTTP 413` response from the Satellite. When this occurred, it put the `HttpClient` in a persistent failure state, unable to send new reports. This set of changes addresses this by resetting the `HttpClient` if we get an invalid response from the Satellite.
* If a null was passed as a tag value, it caused an issue where the tracer was no longer able to send spans due to faulty logic in the protobuf converter. 