### PR TITLE
Guard against malformed spans throwing fatal exceptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+_vNext_
+- Guard against conversion of malformed `SpanData` by dropping bad spans.
 
 _v0.1.0_
 - `TransportOptions` are now available. You can select JSON or Binary Protobufs.

--- a/src/LightStep/Collector/LightStepHttpClient.cs
+++ b/src/LightStep/Collector/LightStepHttpClient.cs
@@ -117,24 +117,35 @@ namespace LightStep.Collector
             var timer = new Stopwatch();
             timer.Start();
 
-            var metrics = new InternalMetrics
-            {
-                StartTimestamp = Timestamp.FromDateTime(spanBuffer.ReportStartTime.ToUniversalTime()),
-                DurationMicros = Convert.ToUInt64((spanBuffer.ReportEndTime - spanBuffer.ReportStartTime).Ticks / 10),
-                Counts = { new MetricsSample() { Name = "spans.dropped", IntValue = spanBuffer.DroppedSpanCount } }
-            };
-            
             var request = new ReportRequest
             {
                 Reporter = new Reporter
                 {
                     ReporterId = _options.TracerGuid
                 },
-                Auth = new Auth {AccessToken = _options.AccessToken},
-                InternalMetrics = metrics
+                Auth = new Auth {AccessToken = _options.AccessToken}
             };
             _options.Tags.ToList().ForEach(t => request.Reporter.Tags.Add(new KeyValue().MakeKeyValueFromKvp(t)));
-            spanBuffer.GetSpans().ToList().ForEach(span => request.Spans.Add(new Span().MakeSpanFromSpanData(span)));
+            spanBuffer.GetSpans().ToList().ForEach(span => {
+                try 
+                {
+                    request.Spans.Add(new Span().MakeSpanFromSpanData(span));
+                }
+                catch (Exception ex)
+                {
+                    _logger.WarnException("Caught exception converting spans.", ex);
+                    spanBuffer.DroppedSpanCount++;
+                }
+            });
+
+            var metrics = new InternalMetrics
+            {
+                StartTimestamp = Timestamp.FromDateTime(spanBuffer.ReportStartTime.ToUniversalTime()),
+                DurationMicros = Convert.ToUInt64((spanBuffer.ReportEndTime - spanBuffer.ReportStartTime).Ticks / 10),
+                Counts = { new MetricsSample() { Name = "spans.dropped", IntValue = spanBuffer.DroppedSpanCount } }
+            };
+            request.InternalMetrics = metrics;
+
             timer.Stop();
             _logger.Debug($"Serialization complete in {timer.ElapsedMilliseconds}ms. Request size: {request.CalculateSize()}b.");
             

--- a/test/LightStep.Tests/LightStepProtoTests.cs
+++ b/test/LightStep.Tests/LightStepProtoTests.cs
@@ -81,6 +81,20 @@ namespace LightStep.Tests
         }
 
         [Fact]
+        public void DroppedSpanCountShouldIncrementOnBadSpan()
+        {
+            var recorder = new SimpleMockRecorder();
+            var badSpan = new SpanData {
+                Duration = new TimeSpan(-1),
+                OperationName = "badSpan"
+            };
+            recorder.RecordSpan(badSpan);
+            var client = GetClient();
+            var translatedBuffer = client.Translate(recorder.GetSpanBuffer());
+            Assert.Equal(1, translatedBuffer.InternalMetrics.Counts[0].IntValue);
+        }
+
+        [Fact]
         public void ConverterShouldConvertValues()
         {
             var recorder = new SimpleMockRecorder();


### PR DESCRIPTION
Fixes #50 

When encountering a malformed `SpanData` object during translation, catch the exception and drop the span.