### PR TITLE
Support meta events in spans

### DIFF
--- a/src/LightStep/Collector/Collector.cs
+++ b/src/LightStep/Collector/Collector.cs
@@ -61,17 +61,18 @@ namespace LightStep.Collector {
             "LkNvbGxlY3Rvci5BdXRoEigKBXNwYW5zGAMgAygLMhkuTGlnaHRTdGVwLkNv",
             "bGxlY3Rvci5TcGFuEh8KF3RpbWVzdGFtcF9vZmZzZXRfbWljcm9zGAUgASgD",
             "Ej4KEGludGVybmFsX21ldHJpY3MYBiABKAsyJC5MaWdodFN0ZXAuQ29sbGVj",
-            "dG9yLkludGVybmFsTWV0cmljcyIaCgdDb21tYW5kEg8KB2Rpc2FibGUYASAB",
-            "KAgi4AEKDlJlcG9ydFJlc3BvbnNlEi4KCGNvbW1hbmRzGAEgAygLMhwuTGln",
-            "aHRTdGVwLkNvbGxlY3Rvci5Db21tYW5kEjUKEXJlY2VpdmVfdGltZXN0YW1w",
-            "GAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBI2ChJ0cmFuc21p",
-            "dF90aW1lc3RhbXAYAyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1w",
-            "Eg4KBmVycm9ycxgEIAMoCRIQCgh3YXJuaW5ncxgFIAMoCRINCgVpbmZvcxgG",
-            "IAMoCTKVAQoQQ29sbGVjdG9yU2VydmljZRKAAQoGUmVwb3J0EiIuTGlnaHRT",
-            "dGVwLkNvbGxlY3Rvci5SZXBvcnRSZXF1ZXN0GiMuTGlnaHRTdGVwLkNvbGxl",
-            "Y3Rvci5SZXBvcnRSZXNwb25zZSItgtPkkwInIg8vYXBpL3YyL3JlcG9ydHM6",
-            "ASpaERIPL2FwaS92Mi9yZXBvcnRzQjEKGWNvbS5saWdodHN0ZXAudHJhY2Vy",
-            "LmdycGNQAVoLY29sbGVjdG9ycGKiAgRMU1BCYgZwcm90bzM="));
+            "dG9yLkludGVybmFsTWV0cmljcyIsCgdDb21tYW5kEg8KB2Rpc2FibGUYASAB",
+            "KAgSEAoIZGV2X21vZGUYAiABKAgi4AEKDlJlcG9ydFJlc3BvbnNlEi4KCGNv",
+            "bW1hbmRzGAEgAygLMhwuTGlnaHRTdGVwLkNvbGxlY3Rvci5Db21tYW5kEjUK",
+            "EXJlY2VpdmVfdGltZXN0YW1wGAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRp",
+            "bWVzdGFtcBI2ChJ0cmFuc21pdF90aW1lc3RhbXAYAyABKAsyGi5nb29nbGUu",
+            "cHJvdG9idWYuVGltZXN0YW1wEg4KBmVycm9ycxgEIAMoCRIQCgh3YXJuaW5n",
+            "cxgFIAMoCRINCgVpbmZvcxgGIAMoCTKVAQoQQ29sbGVjdG9yU2VydmljZRKA",
+            "AQoGUmVwb3J0EiIuTGlnaHRTdGVwLkNvbGxlY3Rvci5SZXBvcnRSZXF1ZXN0",
+            "GiMuTGlnaHRTdGVwLkNvbGxlY3Rvci5SZXBvcnRSZXNwb25zZSItgtPkkwIn",
+            "Ig8vYXBpL3YyL3JlcG9ydHM6ASpaERIPL2FwaS92Mi9yZXBvcnRzQjEKGWNv",
+            "bS5saWdodHN0ZXAudHJhY2VyLmdycGNQAVoLY29sbGVjdG9ycGKiAgRMU1BC",
+            "YgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, global::Google.Api.AnnotationsReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
@@ -85,7 +86,7 @@ namespace LightStep.Collector {
             new pbr::GeneratedClrTypeInfo(typeof(global::LightStep.Collector.InternalMetrics), global::LightStep.Collector.InternalMetrics.Parser, new[]{ "StartTimestamp", "DurationMicros", "Logs", "Counts", "Gauges" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::LightStep.Collector.Auth), global::LightStep.Collector.Auth.Parser, new[]{ "AccessToken" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::LightStep.Collector.ReportRequest), global::LightStep.Collector.ReportRequest.Parser, new[]{ "Reporter", "Auth", "Spans", "TimestampOffsetMicros", "InternalMetrics" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::LightStep.Collector.Command), global::LightStep.Collector.Command.Parser, new[]{ "Disable" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::LightStep.Collector.Command), global::LightStep.Collector.Command.Parser, new[]{ "Disable", "DevMode" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::LightStep.Collector.ReportResponse), global::LightStep.Collector.ReportResponse.Parser, new[]{ "Commands", "ReceiveTimestamp", "TransmitTimestamp", "Errors", "Warnings", "Infos" }, null, null, null)
           }));
     }
@@ -2199,6 +2200,7 @@ namespace LightStep.Collector {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public Command(Command other) : this() {
       disable_ = other.disable_;
+      devMode_ = other.devMode_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -2218,6 +2220,17 @@ namespace LightStep.Collector {
       }
     }
 
+    /// <summary>Field number for the "dev_mode" field.</summary>
+    public const int DevModeFieldNumber = 2;
+    private bool devMode_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool DevMode {
+      get { return devMode_; }
+      set {
+        devMode_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Command);
@@ -2232,6 +2245,7 @@ namespace LightStep.Collector {
         return true;
       }
       if (Disable != other.Disable) return false;
+      if (DevMode != other.DevMode) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -2239,6 +2253,7 @@ namespace LightStep.Collector {
     public override int GetHashCode() {
       int hash = 1;
       if (Disable != false) hash ^= Disable.GetHashCode();
+      if (DevMode != false) hash ^= DevMode.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -2256,6 +2271,10 @@ namespace LightStep.Collector {
         output.WriteRawTag(8);
         output.WriteBool(Disable);
       }
+      if (DevMode != false) {
+        output.WriteRawTag(16);
+        output.WriteBool(DevMode);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -2265,6 +2284,9 @@ namespace LightStep.Collector {
     public int CalculateSize() {
       int size = 0;
       if (Disable != false) {
+        size += 1 + 1;
+      }
+      if (DevMode != false) {
         size += 1 + 1;
       }
       if (_unknownFields != null) {
@@ -2281,6 +2303,9 @@ namespace LightStep.Collector {
       if (other.Disable != false) {
         Disable = other.Disable;
       }
+      if (other.DevMode != false) {
+        DevMode = other.DevMode;
+      }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -2294,6 +2319,10 @@ namespace LightStep.Collector {
             break;
           case 8: {
             Disable = input.ReadBool();
+            break;
+          }
+          case 16: {
+            DevMode = input.ReadBool();
             break;
           }
         }

--- a/src/LightStep/LightStepConstants.cs
+++ b/src/LightStep/LightStepConstants.cs
@@ -17,5 +17,19 @@
         public static readonly string TracerVersionKey = "lightstep.tracer_version";
 
         public static readonly string SatelliteReportPath = "api/v2/reports";
+
+        public static class MetaEvent {
+            public static readonly string MetaEventKey = "lightstep.meta_event";
+            public static readonly string PropagationFormatKey = "lightstep.propagation_format";
+            public static readonly string TraceIdKey = "lightstep.trace_id";
+            public static readonly string SpanIdKey = "lightstep.span_id";
+            public static readonly string TracerGuidKey = "lightstep.tracer_guid";
+            public static readonly string ExtractOperation = "lightstep.extract_span";
+            public static readonly string InjectOperation = "lightstep.inject_span";
+            public static readonly string SpanStartOperation = "lightstep.span_start";
+            public static readonly string SpanFinishOperation = "lightstep.span_finish";
+            public static readonly string TracerCreateOperation = "lightstep.tracer_create";
+        }
+        
     }
 }

--- a/src/LightStep/Options.cs
+++ b/src/LightStep/Options.cs
@@ -65,6 +65,18 @@ namespace LightStep
         /// </summary>
         public TransportOptions Transport { get; private set; }
 
+        /// <summary>
+        ///     Determines if tracer should report meta events to LightStep
+        /// </summary>
+        public Boolean EnableMetaEventLogging { get; private set; }
+
+        public Options WithMetaEventLogging()
+        {
+            _logger.Debug("Enabling Meta Events");
+            EnableMetaEventLogging = true;
+            return this;
+        }
+
         public Options WithToken(string token)
         {
             _logger.Debug($"Setting access token to {token}");
@@ -146,6 +158,7 @@ namespace LightStep
             Run = true;
             ReportMaxSpans = int.MaxValue;
             Transport = TransportOptions.BinaryProto;
+            EnableMetaEventLogging = false;
         }
         
         private IDictionary<string, object> MergeTags(IDictionary<string, object> input)

--- a/src/LightStep/Options.cs
+++ b/src/LightStep/Options.cs
@@ -68,7 +68,7 @@ namespace LightStep
         /// <summary>
         ///     Determines if tracer should report meta events to LightStep
         /// </summary>
-        public Boolean EnableMetaEventLogging { get; private set; }
+        public Boolean EnableMetaEventLogging { get; internal set; }
 
         public Options WithMetaEventLogging()
         {

--- a/src/LightStep/Span.cs
+++ b/src/LightStep/Span.cs
@@ -67,7 +67,7 @@ namespace LightStep
                     parentContext.SpanId);
                 ParentId = parentContext.SpanId;
             }
-            if (_tracer._options.EnableMetaEventLogging) {
+            if (_tracer._options.EnableMetaEventLogging && Utilities.IsNotMetaSpan(this)) {
                 this._tracer.BuildSpan("lightstep.span_created")
                     .Start()
                     .SetTag("lightstep.meta_event", true)
@@ -258,7 +258,7 @@ namespace LightStep
             };
 
             _tracer.AppendFinishedSpan(spanData);
-            if(_tracer._options.EnableMetaEventLogging) {
+            if(_tracer._options.EnableMetaEventLogging && Utilities.IsNotMetaSpan(this)) {
                 _tracer.BuildSpan("lightstep.span_completed")
                     .Start()
                     .SetTag("lightstep.meta_event", true)

--- a/src/LightStep/Span.cs
+++ b/src/LightStep/Span.cs
@@ -69,7 +69,7 @@ namespace LightStep
             }
             if (_tracer._options.EnableMetaEventLogging && Utilities.IsNotMetaSpan(this))
             {
-                _tracer.BuildSpan("lightstep.span_created")
+                _tracer.BuildSpan("lightstep.span_start")
                     .IgnoreActiveSpan()
                     .WithTag("lightstep.meta_event", true)
                     .WithTag("lightstep.span_id", _context.SpanId)
@@ -262,7 +262,7 @@ namespace LightStep
             _tracer.AppendFinishedSpan(spanData);
             if(_tracer._options.EnableMetaEventLogging && Utilities.IsNotMetaSpan(this))
             {
-                _tracer.BuildSpan("lightstep.span_completed")
+                _tracer.BuildSpan("lightstep.span_finish")
                     .IgnoreActiveSpan()
                     .WithTag("lightstep.meta_event", true)
                     .WithTag("lightstep.span_id", this.TypedContext().SpanId)

--- a/src/LightStep/Span.cs
+++ b/src/LightStep/Span.cs
@@ -69,6 +69,7 @@ namespace LightStep
             }
             this._tracer.BuildSpan("lightstep.span_created")
                 .Start()
+                .SetTag("lightstep.meta_event", true)
                 .SetTag("lightstep.span_id", _context.SpanId)
                 .SetTag("lightstep.trace_id", _context.TraceId)
                 .Finish();
@@ -256,6 +257,7 @@ namespace LightStep
             _tracer.AppendFinishedSpan(spanData);
             this._tracer.BuildSpan("lightstep.span_completed")
                 .Start()
+                .SetTag("lightstep.meta_event", true)
                 .SetTag("lightstep.span_id", this.TypedContext().SpanId)
                 .SetTag("lightstep.trace_id", this.TypedContext().TraceId)
                 .Finish();

--- a/src/LightStep/Span.cs
+++ b/src/LightStep/Span.cs
@@ -67,12 +67,13 @@ namespace LightStep
                     parentContext.SpanId);
                 ParentId = parentContext.SpanId;
             }
-            if (_tracer._options.EnableMetaEventLogging && Utilities.IsNotMetaSpan(this)) {
-                this._tracer.BuildSpan("lightstep.span_created")
+            if (_tracer._options.EnableMetaEventLogging && Utilities.IsNotMetaSpan(this))
+            {
+                _tracer.BuildSpan("lightstep.span_created")
+                    .WithTag("lightstep.meta_event", true)
+                    .WithTag("lightstep.span_id", _context.SpanId)
+                    .WithTag("lightstep.trace_id", _context.TraceId)
                     .Start()
-                    .SetTag("lightstep.meta_event", true)
-                    .SetTag("lightstep.span_id", _context.SpanId)
-                    .SetTag("lightstep.trace_id", _context.TraceId)
                     .Finish();
             }
             
@@ -258,12 +259,13 @@ namespace LightStep
             };
 
             _tracer.AppendFinishedSpan(spanData);
-            if(_tracer._options.EnableMetaEventLogging && Utilities.IsNotMetaSpan(this)) {
+            if(_tracer._options.EnableMetaEventLogging && Utilities.IsNotMetaSpan(this))
+            {
                 _tracer.BuildSpan("lightstep.span_completed")
+                    .WithTag("lightstep.meta_event", true)
+                    .WithTag("lightstep.span_id", this.TypedContext().SpanId)
+                    .WithTag("lightstep.trace_id", this.TypedContext().TraceId)
                     .Start()
-                    .SetTag("lightstep.meta_event", true)
-                    .SetTag("lightstep.span_id", this.TypedContext().SpanId)
-                    .SetTag("lightstep.trace_id", this.TypedContext().TraceId)
                     .Finish();
             } 
         }

--- a/src/LightStep/Span.cs
+++ b/src/LightStep/Span.cs
@@ -69,11 +69,11 @@ namespace LightStep
             }
             if (_tracer._options.EnableMetaEventLogging && Utilities.IsNotMetaSpan(this))
             {
-                _tracer.BuildSpan("lightstep.span_start")
+                _tracer.BuildSpan(LightStepConstants.MetaEvent.TracerCreateOperation)
                     .IgnoreActiveSpan()
-                    .WithTag("lightstep.meta_event", true)
-                    .WithTag("lightstep.span_id", _context.SpanId)
-                    .WithTag("lightstep.trace_id", _context.TraceId)
+                    .WithTag(LightStepConstants.MetaEvent.MetaEventKey, true)
+                    .WithTag(LightStepConstants.MetaEvent.SpanIdKey, _context.SpanId)
+                    .WithTag(LightStepConstants.MetaEvent.TraceIdKey, _context.TraceId)
                     .Start()
                     .Finish();
             }
@@ -262,11 +262,11 @@ namespace LightStep
             _tracer.AppendFinishedSpan(spanData);
             if(_tracer._options.EnableMetaEventLogging && Utilities.IsNotMetaSpan(this))
             {
-                _tracer.BuildSpan("lightstep.span_finish")
+                _tracer.BuildSpan(LightStepConstants.MetaEvent.SpanFinishOperation)
                     .IgnoreActiveSpan()
-                    .WithTag("lightstep.meta_event", true)
-                    .WithTag("lightstep.span_id", this.TypedContext().SpanId)
-                    .WithTag("lightstep.trace_id", this.TypedContext().TraceId)
+                    .WithTag(LightStepConstants.MetaEvent.MetaEventKey, true)
+                    .WithTag(LightStepConstants.MetaEvent.SpanIdKey, this.TypedContext().SpanId)
+                    .WithTag(LightStepConstants.MetaEvent.TraceIdKey, this.TypedContext().TraceId)
                     .Start()
                     .Finish();
             } 

--- a/src/LightStep/Span.cs
+++ b/src/LightStep/Span.cs
@@ -67,6 +67,11 @@ namespace LightStep
                     parentContext.SpanId);
                 ParentId = parentContext.SpanId;
             }
+            this._tracer.BuildSpan("lightstep.span_created")
+                .Start()
+                .SetTag("lightstep.span_id", _context.SpanId)
+                .SetTag("lightstep.trace_id", _context.TraceId)
+                .Finish();
         }
 
         /// <summary>
@@ -249,6 +254,11 @@ namespace LightStep
             };
 
             _tracer.AppendFinishedSpan(spanData);
+            this._tracer.BuildSpan("lightstep.span_completed")
+                .Start()
+                .SetTag("lightstep.span_id", this.TypedContext().SpanId)
+                .SetTag("lightstep.trace_id", this.TypedContext().TraceId)
+                .Finish();
         }
 
         #region Setters

--- a/src/LightStep/Span.cs
+++ b/src/LightStep/Span.cs
@@ -70,6 +70,7 @@ namespace LightStep
             if (_tracer._options.EnableMetaEventLogging && Utilities.IsNotMetaSpan(this))
             {
                 _tracer.BuildSpan("lightstep.span_created")
+                    .IgnoreActiveSpan()
                     .WithTag("lightstep.meta_event", true)
                     .WithTag("lightstep.span_id", _context.SpanId)
                     .WithTag("lightstep.trace_id", _context.TraceId)
@@ -262,6 +263,7 @@ namespace LightStep
             if(_tracer._options.EnableMetaEventLogging && Utilities.IsNotMetaSpan(this))
             {
                 _tracer.BuildSpan("lightstep.span_completed")
+                    .IgnoreActiveSpan()
                     .WithTag("lightstep.meta_event", true)
                     .WithTag("lightstep.span_id", this.TypedContext().SpanId)
                     .WithTag("lightstep.trace_id", this.TypedContext().TraceId)

--- a/src/LightStep/Span.cs
+++ b/src/LightStep/Span.cs
@@ -67,12 +67,15 @@ namespace LightStep
                     parentContext.SpanId);
                 ParentId = parentContext.SpanId;
             }
-            this._tracer.BuildSpan("lightstep.span_created")
-                .Start()
-                .SetTag("lightstep.meta_event", true)
-                .SetTag("lightstep.span_id", _context.SpanId)
-                .SetTag("lightstep.trace_id", _context.TraceId)
-                .Finish();
+            if (_tracer._options.EnableMetaEventLogging) {
+                this._tracer.BuildSpan("lightstep.span_created")
+                    .Start()
+                    .SetTag("lightstep.meta_event", true)
+                    .SetTag("lightstep.span_id", _context.SpanId)
+                    .SetTag("lightstep.trace_id", _context.TraceId)
+                    .Finish();
+            }
+            
         }
 
         /// <summary>
@@ -255,12 +258,14 @@ namespace LightStep
             };
 
             _tracer.AppendFinishedSpan(spanData);
-            this._tracer.BuildSpan("lightstep.span_completed")
-                .Start()
-                .SetTag("lightstep.meta_event", true)
-                .SetTag("lightstep.span_id", this.TypedContext().SpanId)
-                .SetTag("lightstep.trace_id", this.TypedContext().TraceId)
-                .Finish();
+            if(_tracer._options.EnableMetaEventLogging) {
+                _tracer.BuildSpan("lightstep.span_completed")
+                    .Start()
+                    .SetTag("lightstep.meta_event", true)
+                    .SetTag("lightstep.span_id", this.TypedContext().SpanId)
+                    .SetTag("lightstep.trace_id", this.TypedContext().TraceId)
+                    .Finish();
+            } 
         }
 
         #region Setters

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -17,7 +17,7 @@ namespace LightStep
     public sealed class Tracer : ITracer
     {
         private readonly object _lock = new object();
-        public readonly Options _options;
+        internal readonly Options _options;
         private readonly IPropagator _propagator;
         private readonly LightStepHttpClient _httpClient;
         private ISpanRecorder _spanRecorder;

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -83,6 +83,7 @@ namespace LightStep
             _propagator.Inject((SpanContext) spanContext, format, carrier);
             if (_options.EnableMetaEventLogging) {
                 this.BuildSpan("lightstep.inject_span")
+                    .IgnoreActiveSpan()
                     .WithTag("lightstep.meta_event", true)
                     .WithTag("lightstep.span_id", spanContext.SpanId)
                     .WithTag("lightstep.trace_id", spanContext.TraceId)
@@ -98,6 +99,7 @@ namespace LightStep
             var ctx = _propagator.Extract(format, carrier);
             if (_options.EnableMetaEventLogging) {
                 this.BuildSpan("lightstep.extract_span")
+                    .IgnoreActiveSpan()
                     .WithTag("lightstep.meta_event", true)
                     .WithTag("lightstep.span_id", ctx.SpanId)
                     .WithTag("lightstep.trace_id", ctx.TraceId)

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -63,14 +63,6 @@ namespace LightStep
             _httpClient = new LightStepHttpClient(url, _options);
             _logger.Debug($"Tracer is reporting to {url}.");          
             _reportLoop = new Timer(e => Flush(), null, TimeSpan.Zero, _options.ReportPeriod);
-            
-            if (_options.EnableMetaEventLogging) {
-                this.BuildSpan("lightstep.tracer_created")
-                    .Start()
-                    .SetTag("lightstep.meta_event", true)
-                    .SetTag("lightstep.tracer_guid", _options.TracerGuid)
-                    .Finish();     
-            }
         }
 
         /// <inheritdoc />

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -83,11 +83,11 @@ namespace LightStep
             _propagator.Inject((SpanContext) spanContext, format, carrier);
             if (_options.EnableMetaEventLogging) {
                 this.BuildSpan("lightstep.inject_span")
+                    .WithTag("lightstep.meta_event", true)
+                    .WithTag("lightstep.span_id", spanContext.SpanId)
+                    .WithTag("lightstep.trace_id", spanContext.TraceId)
+                    .WithTag("lightstep.propagation_format", format.GetType().ToString())
                     .Start()
-                    .SetTag("lightstep.meta_event", true)
-                    .SetTag("lightstep.span_id", spanContext.SpanId)
-                    .SetTag("lightstep.trace_id", spanContext.TraceId)
-                    .SetTag("lightstep.propagation_format", format.GetType().ToString())
                     .Finish();
             }
         }
@@ -98,11 +98,11 @@ namespace LightStep
             var ctx = _propagator.Extract(format, carrier);
             if (_options.EnableMetaEventLogging) {
                 this.BuildSpan("lightstep.extract_span")
+                    .WithTag("lightstep.meta_event", true)
+                    .WithTag("lightstep.span_id", ctx.SpanId)
+                    .WithTag("lightstep.trace_id", ctx.TraceId)
+                    .WithTag("lightstep.propagation_format", format.GetType().ToString())
                     .Start()
-                    .SetTag("lightstep.meta_event", true)
-                    .SetTag("lightstep.span_id", ctx.SpanId)
-                    .SetTag("lightstep.trace_id", ctx.TraceId)
-                    .SetTag("lightstep.propagation_format", format.GetType().ToString())
                     .Finish();
             }
             return ctx;

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -64,7 +64,11 @@ namespace LightStep
             _logger.Debug($"Tracer is reporting to {url}.");          
             _reportLoop = new Timer(e => Flush(), null, TimeSpan.Zero, _options.ReportPeriod);
 
-            this.BuildSpan("lightstep.tracer_created").Start().SetTag("lightstep.tracer_guid", _options.TracerGuid).Finish();     
+            this.BuildSpan("lightstep.tracer_created")
+                .Start()
+                .SetTag("lightstep.meta_event", true)
+                .SetTag("lightstep.tracer_guid", _options.TracerGuid)
+                .Finish();     
         }
 
         /// <inheritdoc />

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -17,7 +17,7 @@ namespace LightStep
     public sealed class Tracer : ITracer
     {
         private readonly object _lock = new object();
-        private readonly Options _options;
+        public readonly Options _options;
         private readonly IPropagator _propagator;
         private readonly LightStepHttpClient _httpClient;
         private ISpanRecorder _spanRecorder;
@@ -63,12 +63,14 @@ namespace LightStep
             _httpClient = new LightStepHttpClient(url, _options);
             _logger.Debug($"Tracer is reporting to {url}.");          
             _reportLoop = new Timer(e => Flush(), null, TimeSpan.Zero, _options.ReportPeriod);
-
-            this.BuildSpan("lightstep.tracer_created")
-                .Start()
-                .SetTag("lightstep.meta_event", true)
-                .SetTag("lightstep.tracer_guid", _options.TracerGuid)
-                .Finish();     
+            
+            if (_options.EnableMetaEventLogging) {
+                this.BuildSpan("lightstep.tracer_created")
+                    .Start()
+                    .SetTag("lightstep.meta_event", true)
+                    .SetTag("lightstep.tracer_guid", _options.TracerGuid)
+                    .Finish();     
+            }
         }
 
         /// <inheritdoc />
@@ -87,26 +89,30 @@ namespace LightStep
         public void Inject<TCarrier>(ISpanContext spanContext, IFormat<TCarrier> format, TCarrier carrier)
         {
             _propagator.Inject((SpanContext) spanContext, format, carrier);
-            this.BuildSpan("lightstep.inject_span")
-                .Start()
-                .SetTag("lightstep.meta_event", true)
-                .SetTag("lightstep.span_id", spanContext.SpanId)
-                .SetTag("lightstep.trace_id", spanContext.TraceId)
-                .SetTag("lightstep.propagation_format", format.GetType().ToString())
-                .Finish();
+            if (_options.EnableMetaEventLogging) {
+                this.BuildSpan("lightstep.inject_span")
+                    .Start()
+                    .SetTag("lightstep.meta_event", true)
+                    .SetTag("lightstep.span_id", spanContext.SpanId)
+                    .SetTag("lightstep.trace_id", spanContext.TraceId)
+                    .SetTag("lightstep.propagation_format", format.GetType().ToString())
+                    .Finish();
+            }
         }
 
         /// <inheritdoc />
         public ISpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
         {
             var ctx = _propagator.Extract(format, carrier);
-            this.BuildSpan("lightstep.extract_span")
-                .Start()
-                .SetTag("lightstep.meta_event", true)
-                .SetTag("lightstep.span_id", ctx.SpanId)
-                .SetTag("lightstep.trace_id", ctx.TraceId)
-                .SetTag("lightstep.propagation_format", format.GetType().ToString())
-                .Finish();
+            if (_options.EnableMetaEventLogging) {
+                this.BuildSpan("lightstep.extract_span")
+                    .Start()
+                    .SetTag("lightstep.meta_event", true)
+                    .SetTag("lightstep.span_id", ctx.SpanId)
+                    .SetTag("lightstep.trace_id", ctx.TraceId)
+                    .SetTag("lightstep.propagation_format", format.GetType().ToString())
+                    .Finish();
+            }
             return ctx;
         }
 

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -84,12 +84,12 @@ namespace LightStep
         {
             _propagator.Inject((SpanContext) spanContext, format, carrier);
             if (_options.EnableMetaEventLogging) {
-                this.BuildSpan("lightstep.inject_span")
+                this.BuildSpan(LightStepConstants.MetaEvent.InjectOperation)
                     .IgnoreActiveSpan()
-                    .WithTag("lightstep.meta_event", true)
-                    .WithTag("lightstep.span_id", spanContext.SpanId)
-                    .WithTag("lightstep.trace_id", spanContext.TraceId)
-                    .WithTag("lightstep.propagation_format", format.GetType().ToString())
+                    .WithTag(LightStepConstants.MetaEvent.MetaEventKey, true)
+                    .WithTag(LightStepConstants.MetaEvent.SpanIdKey, spanContext.SpanId)
+                    .WithTag(LightStepConstants.MetaEvent.TraceIdKey, spanContext.TraceId)
+                    .WithTag(LightStepConstants.MetaEvent.PropagationFormatKey, format.GetType().ToString())
                     .Start()
                     .Finish();
             }
@@ -100,12 +100,12 @@ namespace LightStep
         {
             var ctx = _propagator.Extract(format, carrier);
             if (_options.EnableMetaEventLogging) {
-                this.BuildSpan("lightstep.extract_span")
+                this.BuildSpan(LightStepConstants.MetaEvent.ExtractOperation)
                     .IgnoreActiveSpan()
-                    .WithTag("lightstep.meta_event", true)
-                    .WithTag("lightstep.span_id", ctx.SpanId)
-                    .WithTag("lightstep.trace_id", ctx.TraceId)
-                    .WithTag("lightstep.propagation_format", format.GetType().ToString())
+                    .WithTag(LightStepConstants.MetaEvent.MetaEventKey, true)
+                    .WithTag(LightStepConstants.MetaEvent.SpanIdKey, ctx.SpanId)
+                    .WithTag(LightStepConstants.MetaEvent.TraceIdKey, ctx.TraceId)
+                    .WithTag(LightStepConstants.MetaEvent.PropagationFormatKey, format.GetType().ToString())
                     .Start()
                     .Finish();
             }
@@ -122,10 +122,10 @@ namespace LightStep
             {
                 if (_options.EnableMetaEventLogging && _firstReportHasRun == false)
                 {
-                    BuildSpan("lightstep.tracer_create")
+                    BuildSpan(LightStepConstants.MetaEvent.TracerCreateOperation)
                         .IgnoreActiveSpan()
-                        .WithTag("lightstep.meta_event", true)
-                        .WithTag("lightstep.tracer_guid", _options.TracerGuid)
+                        .WithTag(LightStepConstants.MetaEvent.MetaEventKey, true)
+                        .WithTag(LightStepConstants.MetaEvent.TracerGuidKey, _options.TracerGuid)
                         .Start()
                         .Finish();
                     _firstReportHasRun = true;

--- a/src/LightStep/Utilities.cs
+++ b/src/LightStep/Utilities.cs
@@ -21,7 +21,7 @@ namespace LightStep
 
         public static bool IsNotMetaSpan(Span span) 
         {
-            return span.Tags.ContainsKey("lightstep.meta_event");
+            return !span.Tags.ContainsKey("lightstep.meta_event");
         }
     }
 }

--- a/src/LightStep/Utilities.cs
+++ b/src/LightStep/Utilities.cs
@@ -18,5 +18,10 @@ namespace LightStep
             rand.NextBytes(buffer);
             return BitConverter.ToUInt64(buffer, 0);
         }
+
+        public static bool IsNotMetaSpan(Span span) 
+        {
+            return span.Tags.ContainsKey("lightstep.meta_event");
+        }
     }
 }

--- a/src/LightStep/Utilities.cs
+++ b/src/LightStep/Utilities.cs
@@ -21,7 +21,7 @@ namespace LightStep
 
         public static bool IsNotMetaSpan(Span span) 
         {
-            return !span.Tags.ContainsKey("lightstep.meta_event");
+            return !span.Tags.ContainsKey(LightStepConstants.MetaEvent.MetaEventKey);
         }
     }
 }

--- a/src/LightStep/collector.proto
+++ b/src/LightStep/collector.proto
@@ -91,6 +91,7 @@ message ReportRequest {
 
 message Command {
     bool disable = 1;
+    bool dev_mode = 2;
 }
 
 message ReportResponse {


### PR DESCRIPTION
This PR enables the reporting of 'meta events', spans that report diagnostic-level information about span and tracer lifecycle. This feature is disabled by default and needs to be turned on via calling `WithMetaEventLogging`. Please note, this feature is _not_ suited to being run in a production environment due to the large amount of spans generated.