### PR TITLE
Don't attempt to parse all strings as JSON when serializing tags.

### DIFF
--- a/src/LightStep/Collector/ProtoConverterExtensions.cs
+++ b/src/LightStep/Collector/ProtoConverterExtensions.cs
@@ -45,16 +45,12 @@ namespace LightStep.Collector
 
         public static bool IsJson(this object value)
         {
-            try
-            {
-                JsonValue.Parse(value.ToString());
+            if (value is String) {
+                var st = (String)value;
+                st = st.Trim(' ').Trim('"');
+                return (st[0] == '{' || st[0] == '[') && (st[st.Length -1] == '}' || st[st.Length - 1] == ']');
             }
-            catch (Exception)
-            {
-                return false;
-            }
-
-            return true;
+            return false;
         }
     }
 }

--- a/src/LightStep/Collector/ProtoConverterExtensions.cs
+++ b/src/LightStep/Collector/ProtoConverterExtensions.cs
@@ -48,7 +48,9 @@ namespace LightStep.Collector
             if (value is String) {
                 var st = (String)value;
                 st = st.Trim(' ').Trim('"');
-                return (st[0] == '{' || st[0] == '[') && (st[st.Length -1] == '}' || st[st.Length - 1] == ']');
+                if (st.Length > 0) {
+                    return (st[0] == '{' || st[0] == '[') && (st[st.Length -1] == '}' || st[st.Length - 1] == ']');
+                }
             }
             return false;
         }


### PR DESCRIPTION
Currently, we check all string values to see if they're well-formed JSON. This is rather expensive, however, as we're throwing and catching an exception for every string. This switches to a more naive method of checking for JSON which should still be OK.