### PR TITLE
put translate into try block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+_v0.4.3_
+- Improves safety of serializing reports by moving translate method to a try/catch block.
 
 _v0.4.2_
 - Addresses an issue where an unhandled exception could occur if a span duration was negative.

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -149,10 +149,11 @@ namespace LightStep
                  */
                 currentDroppedSpanCount += currentBuffer.DroppedSpanCount;
                 currentBuffer.DroppedSpanCount = currentDroppedSpanCount;
-                var data = _httpClient.Translate(currentBuffer);
-
+                
                 try
                 {
+                    // since translate can throw exceptions, place it in the try and drop spans as appropriate
+                    var data = _httpClient.Translate(currentBuffer);
                     var resp = await _httpClient.SendReport(data);
                     
                     if (resp.Errors.Count > 0)


### PR DESCRIPTION
In the (hopefully unlikely) event that a serialization error occurs when translating reports, this change will make the operation safe by dropping the spans to prevent unhandled exceptions from crashing the runtime.