### PR TITLE
Add an exception handler to the tracer

### DIFF
--- a/src/LightStep/Collector/ILightStepHttpClient.cs
+++ b/src/LightStep/Collector/ILightStepHttpClient.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+
+namespace LightStep.Collector
+{
+    public interface ILightStepHttpClient
+    {
+        /// <summary>
+        ///     Send a report of spans to the LightStep Satellite.
+        /// </summary>
+        /// <param name="report">An <see cref="ReportRequest" /></param>
+        /// <returns>A <see cref="ReportResponse" />. This is usually not very interesting.</returns>
+        Task<ReportResponse> SendReport(ReportRequest report);
+
+        /// <summary>
+        ///     Translate SpanData to a protobuf ReportRequest for sending to the Satellite.
+        /// </summary>
+        /// <param name="spans">An enumerable of <see cref="SpanData" /></param>
+        /// <returns>A <see cref="ReportRequest" /></returns>
+        ReportRequest Translate(ISpanRecorder spanBuffer);
+    }
+}

--- a/src/LightStep/Collector/LightStepHttpClient.cs
+++ b/src/LightStep/Collector/LightStepHttpClient.cs
@@ -14,7 +14,7 @@ namespace LightStep.Collector
     /// <summary>
     ///     Contains methods to communicate to a LightStep Satellite via Proto over HTTP.
     /// </summary>
-    public class LightStepHttpClient
+    public class LightStepHttpClient : ILightStepHttpClient
     {
         private readonly Options _options;
         private HttpClient _client;
@@ -69,7 +69,7 @@ namespace LightStep.Collector
         /// <param name="report">An <see cref="ReportRequest" /></param>
         /// <returns>A <see cref="ReportResponse" />. This is usually not very interesting.</returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal async Task<ReportResponse> SendReport(ReportRequest report)
+        public async Task<ReportResponse> SendReport(ReportRequest report)
         {
             // force net45 to attempt tls12 first and fallback appropriately
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
@@ -116,7 +116,7 @@ namespace LightStep.Collector
         /// </summary>
         /// <param name="spans">An enumerable of <see cref="SpanData" /></param>
         /// <returns>A <see cref="ReportRequest" /></returns>
-        internal ReportRequest Translate(ISpanRecorder spanBuffer)
+        public ReportRequest Translate(ISpanRecorder spanBuffer)
         {
             _logger.Debug($"Serializing {spanBuffer.GetSpans().Count()} spans to proto.");
             var timer = new Stopwatch();

--- a/src/LightStep/Options.cs
+++ b/src/LightStep/Options.cs
@@ -70,6 +70,9 @@ namespace LightStep
         /// </summary>
         public Boolean EnableMetaEventLogging { get; internal set; }
 
+        public Action<Exception> ExceptionHandler { get; internal set; }
+        public Boolean ExceptionHandlerRegistered { get; internal set; }
+
         public Options WithMetaEventLogging()
         {
             _logger.Debug("Enabling Meta Events");
@@ -139,6 +142,14 @@ namespace LightStep
             Transport = transport;
             return this;
         }
+
+        public Options WithExceptionHandler(Action<Exception> handler)
+        {
+            _logger.Debug($"Registering exception handler {handler}");
+            ExceptionHandler = handler;
+            ExceptionHandlerRegistered = true;
+            return this;
+        }
         
         /// <summary>
         ///     Creates a new set of options for the LightStep tracer.
@@ -156,6 +167,7 @@ namespace LightStep
             ReportMaxSpans = int.MaxValue;
             Transport = TransportOptions.BinaryProto;
             EnableMetaEventLogging = false;
+            ExceptionHandlerRegistered = false;
         }
         
         private IDictionary<string, object> MergeTags(IDictionary<string, object> input)


### PR DESCRIPTION
(Fixes #68)

This change adds a new field to `Options` that allows users to register a general exception handler of `Action<Exception>` that we will call back when an exception is caught during sending a report.