### PR TITLE
Support binary (x-ot-span-context) header inject/extract.

### DIFF
--- a/examples/LightStep.CSharpAspectTestApp/LightStep.CSharpAspectTestApp.csproj
+++ b/examples/LightStep.CSharpAspectTestApp/LightStep.CSharpAspectTestApp.csproj
@@ -35,8 +35,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTracing, Version=0.12.0.0, Culture=neutral, PublicKeyToken=61503406977abdaf, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OpenTracing.0.12.0\lib\net45\OpenTracing.dll</HintPath>
+    <Reference Include="OpenTracing, Version=0.12.1.0, Culture=neutral, PublicKeyToken=61503406977abdaf">
+      <HintPath>..\..\packages\OpenTracing.0.12.1-rc4\lib\net45\OpenTracing.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="PostSharp, Version=6.0.27.0, Culture=neutral, PublicKeyToken=b13fd38b8f9c99d7, processorArchitecture=MSIL">
       <HintPath>..\..\packages\PostSharp.Redist.6.0.27\lib\net45\PostSharp.dll</HintPath>

--- a/examples/LightStep.CSharpAspectTestApp/packages.config
+++ b/examples/LightStep.CSharpAspectTestApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenTracing" version="0.12.0" targetFramework="net461" />
+  <package id="OpenTracing" version="0.12.1-rc4" targetFramework="net461" />
   <package id="PostSharp" version="6.0.27" targetFramework="net461" />
   <package id="PostSharp.Redist" version="6.0.27" targetFramework="net461" />
 </packages>

--- a/examples/LightStep.CSharpDITestApp/LightStep.CSharpDITestApp.csproj
+++ b/examples/LightStep.CSharpDITestApp/LightStep.CSharpDITestApp.csproj
@@ -41,8 +41,8 @@
       <HintPath>..\..\packages\Castle.Windsor.4.1.1\lib\net45\Castle.Windsor.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OpenTracing, Version=0.12.0.0, Culture=neutral, PublicKeyToken=61503406977abdaf">
-      <HintPath>..\..\packages\OpenTracing.0.12.0\lib\net45\OpenTracing.dll</HintPath>
+    <Reference Include="OpenTracing, Version=0.12.1.0, Culture=neutral, PublicKeyToken=61503406977abdaf">
+      <HintPath>..\..\packages\OpenTracing.0.12.1-rc4\lib\net45\OpenTracing.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/examples/LightStep.CSharpDITestApp/packages.config
+++ b/examples/LightStep.CSharpDITestApp/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Castle.Core" version="4.2.0" targetFramework="net471" />
   <package id="Castle.Windsor" version="4.1.1" targetFramework="net471" />
-  <package id="OpenTracing" version="0.12.0" targetFramework="net471" />
+  <package id="OpenTracing" version="0.12.1-rc4" targetFramework="net471" />
 </packages>

--- a/examples/LightStep.CSharpTestApp/LightStep.CSharpTestApp.csproj
+++ b/examples/LightStep.CSharpTestApp/LightStep.CSharpTestApp.csproj
@@ -6,7 +6,8 @@
     <RootNamespace>LightStep.CSharpTestApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTracing" Version="0.12.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="OpenTracing" Version="0.12.1-rc4" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>

--- a/src/LightStep/LightStep.csproj
+++ b/src/LightStep/LightStep.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="OpenTracing" Version="0.12.0" />
+    <PackageReference Include="OpenTracing" Version="0.12.1-rc4" />
     <PackageReference Include="System.Json" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/LightStep/Propagation/EnvoyPropagator.cs
+++ b/src/LightStep/Propagation/EnvoyPropagator.cs
@@ -20,7 +20,7 @@ namespace LightStep.Propagation
                 {
                     BasicCtx = new BasicTracerCarrier
                     {
-                        SpanId = Convert.ToUInt64(context.SpanId), TraceId = Convert.ToUInt64(context.TraceId)
+                        SpanId = Convert.ToUInt64(context.SpanId), TraceId = Convert.ToUInt64(context.TraceId), Sampled = true
                     }
                 };
                 foreach (var item in context.GetBaggageItems()) ctx.BasicCtx.BaggageItems.Add(item.Key, item.Value);

--- a/src/LightStep/Propagation/EnvoyPropagator.cs
+++ b/src/LightStep/Propagation/EnvoyPropagator.cs
@@ -9,36 +9,33 @@ namespace LightStep.Propagation
     public class EnvoyPropagator : IPropagator
     {
         private static readonly ILog _logger = LogProvider.GetCurrentClassLogger();
-        private const string HeaderName = "X-OT-Span-Context";
-        
+
         /// <inheritdoc />
         public void Inject<TCarrier>(SpanContext context, IFormat<TCarrier> format, TCarrier carrier)
-        {/*
+        {
             _logger.Trace($"Injecting {context} of {format.GetType()} to {carrier.GetType()}");
-            if (carrier is Stream)
+            if (carrier is IBinary s)
             {
                 var ctx = new BinaryCarrier
                 {
-                    BasicCtx =
+                    BasicCtx = new BasicTracerCarrier
                     {
                         SpanId = Convert.ToUInt64(context.SpanId), TraceId = Convert.ToUInt64(context.TraceId)
                     }
                 };
                 foreach (var item in context.GetBaggageItems()) ctx.BasicCtx.BaggageItems.Add(item.Key, item.Value);
-                carrier = ctx.ToByteArray();
-            }*/
-            throw new System.NotImplementedException();
+                var ctxArray = ctx.ToByteArray();
+                var ctxStream = new MemoryStream(ctxArray);
+                s.Set(ctxStream);
+            }
         }
 
         /// <inheritdoc />
         public SpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
         {
-            if (carrier is Stream)
+            if (carrier is IBinary s)
             {
-                // we need to coerce the carrier into a stream as it can't be cast through the pattern match (but it can only ever be a stream)
-                var h = (object) carrier;
-                var st = (Stream) h;
-                var ctx = BinaryCarrier.Parser.ParseFrom(st);
+                var ctx = BinaryCarrier.Parser.ParseFrom(s.Get());
                 var traceId = ctx.BasicCtx.TraceId;
                 var spanId = ctx.BasicCtx.SpanId;
                 var baggage = new Baggage();

--- a/src/LightStep/Propagation/EnvoyPropagator.cs
+++ b/src/LightStep/Propagation/EnvoyPropagator.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using Google.Protobuf;
+using LightStep.Logging;
+using OpenTracing.Propagation;
+
+namespace LightStep.Propagation
+{
+    public class EnvoyPropagator : IPropagator
+    {
+        private static readonly ILog _logger = LogProvider.GetCurrentClassLogger();
+        private const string HeaderName = "X-OT-Span-Context";
+        
+        /// <inheritdoc />
+        public void Inject<TCarrier>(SpanContext context, IFormat<TCarrier> format, TCarrier carrier)
+        {/*
+            _logger.Trace($"Injecting {context} of {format.GetType()} to {carrier.GetType()}");
+            if (carrier is Stream)
+            {
+                var ctx = new BinaryCarrier
+                {
+                    BasicCtx =
+                    {
+                        SpanId = Convert.ToUInt64(context.SpanId), TraceId = Convert.ToUInt64(context.TraceId)
+                    }
+                };
+                foreach (var item in context.GetBaggageItems()) ctx.BasicCtx.BaggageItems.Add(item.Key, item.Value);
+                carrier = ctx.ToByteArray();
+            }*/
+            throw new System.NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public SpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
+        {
+            if (carrier is Stream)
+            {
+                // we need to coerce the carrier into a stream as it can't be cast through the pattern match (but it can only ever be a stream)
+                var h = (object) carrier;
+                var st = (Stream) h;
+                var ctx = BinaryCarrier.Parser.ParseFrom(st);
+                var traceId = ctx.BasicCtx.TraceId;
+                var spanId = ctx.BasicCtx.SpanId;
+                var baggage = new Baggage();
+                foreach (var item in ctx.BasicCtx.BaggageItems)
+                {
+                    baggage.Set(item.Key, item.Value);
+                }
+                return new SpanContext(traceId.ToString(), spanId.ToString(), baggage);
+            }
+
+            return null;
+        }
+    }
+}

--- a/test/LightStep.Tests/PropagatorTests.cs
+++ b/test/LightStep.Tests/PropagatorTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using LightStep.Propagation;
 using OpenTracing.Propagation;
 using Xunit;
@@ -104,6 +106,17 @@ namespace LightStep.Tests
                 Assert.Equal(context.TraceId, extractedContext.TraceId);
                 Assert.Equal(context.SpanId, extractedContext.SpanId);
             }
+        }
+
+        [Fact]
+        public void EnvoyPropagatorShouldDecodeABinaryContext()
+        {
+            var envoyPropagator = new EnvoyPropagator();
+            var bs = Convert.FromBase64String("EhQJQwUbbwmQEc4RPaEuilTou0QYAQ==");
+            var streamCarrier = new MemoryStream(bs);
+
+            var extractedContext = envoyPropagator.Extract(BuiltinFormats.Binary, streamCarrier);
+            Assert.NotNull(extractedContext);
         }
 
         [Fact]

--- a/test/LightStep.Tests/PropagatorTests.cs
+++ b/test/LightStep.Tests/PropagatorTests.cs
@@ -109,14 +109,24 @@ namespace LightStep.Tests
         }
 
         [Fact]
-        public void EnvoyPropagatorShouldDecodeABinaryContext()
+        public void EnvoyPropagatorShouldDecodeABinaryContextFromString()
         {
+            var base64Context = "EhQJQwUbbwmQEc4RPaEuilTou0QYAQ==";
+            var bs = Convert.FromBase64String(base64Context);
+            
             var envoyPropagator = new EnvoyPropagator();
-            var bs = Convert.FromBase64String("EhQJQwUbbwmQEc4RPaEuilTou0QYAQ==");
             var streamCarrier = new MemoryStream(bs);
 
             var extractedContext = envoyPropagator.Extract(BuiltinFormats.Binary, new BinaryExtractAdapter(streamCarrier));
             Assert.NotNull(extractedContext);
+            Assert.Equal("4952807665017200957", extractedContext.SpanId);
+            Assert.Equal("14848807816610383171", extractedContext.TraceId);
+            
+            var reStreamCarrier = new MemoryStream();
+            envoyPropagator.Inject(extractedContext, BuiltinFormats.Binary, new BinaryInjectAdapter(reStreamCarrier));
+            var reBase64String = Convert.ToBase64String(reStreamCarrier.ToArray());
+            Assert.NotNull(reStreamCarrier);
+            Assert.Equal(base64Context, reBase64String);
         }
 
         [Fact]


### PR DESCRIPTION
This functionality is exposed through `EnvoyPropagator` as this is the most common use I've seen. Inject and Extract are both implemented.

Note that this PR is not ready to merge - it requires `v0.12.1` of opentracing-csharp to be released before builds will work.