### PR TITLE
fix(http-header-extract): Header case sensitivity

### DIFF
--- a/src/LightStep/Propagation/HttpHeadersPropagator.cs
+++ b/src/LightStep/Propagation/HttpHeadersPropagator.cs
@@ -1,3 +1,4 @@
+using System;
 using OpenTracing.Propagation;
 
 namespace LightStep.Propagation
@@ -19,7 +20,7 @@ namespace LightStep.Propagation
         public SpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
         {
             var textMapPropagator = new TextMapPropagator();
-            return textMapPropagator.Extract(format, carrier);
+            return textMapPropagator.Extract(format, carrier, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/LightStep/Propagation/TextMapPropagator.cs
+++ b/src/LightStep/Propagation/TextMapPropagator.cs
@@ -30,21 +30,26 @@ namespace LightStep.Propagation
         /// <inheritdoc />
         public SpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
         {
+            return Extract(format, carrier, StringComparison.Ordinal);
+        }
+
+        public SpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier, StringComparison comparison)
+        {
             _logger.Trace($"Extracting {format.GetType()} from {carrier.GetType()}");
             string traceId = null;
             string spanId = null;
             var baggage = new Baggage();
             if (carrier is ITextMap text)
                 foreach (var entry in text)
-                    if (Keys.TraceId.Equals(entry.Key))
+                    if (Keys.TraceId.Equals(entry.Key, comparison))
                     {
                         traceId = Convert.ToUInt64(entry.Value, 16).ToString();
                     }
-                    else if (Keys.SpanId.Equals(entry.Key))
+                    else if (Keys.SpanId.Equals(entry.Key, comparison))
                     {
                         spanId = Convert.ToUInt64(entry.Value, 16).ToString();
                     }
-                    else if (entry.Key.StartsWith(Keys.BaggagePrefix))
+                    else if (entry.Key.StartsWith(Keys.BaggagePrefix, comparison))
                     {
                         var key = entry.Key.Substring(Keys.BaggagePrefix.Length);
                         baggage.Set(key, entry.Value);


### PR DESCRIPTION
Currently, the HttpHeadersPropagator seems to be case sensitive and rejects headers like "Ot-Tracer-Traceid" and only matches "ot-tracer-traceid".
This change makes the comparison OrdinalIgnoreCase for HttpHeadersPropagator without changing exposed behaviour of TextMapPropagator which is used by HttpHeadersPropagator.