### PR TITLE
fix(finished-span-actions): Don't throw exceptions

### DIFF
--- a/src/LightStep/Span.cs
+++ b/src/LightStep/Span.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
+using LightStep.Logging;
 using OpenTracing;
 using OpenTracing.Tag;
 
@@ -20,6 +21,8 @@ namespace LightStep
         private readonly Tracer _tracer;
         private bool _finished;
         private DateTimeOffset _finishTimestamp;
+
+        private static readonly ILog _logger = LogProvider.GetCurrentClassLogger();
 
         /// <summary>
         ///     Create a new Span.
@@ -233,7 +236,7 @@ namespace LightStep
             {
                 var ex = new InvalidOperationException(string.Format(format, args));
                 _errors.Add(ex);
-                throw ex;
+                _logger.Error(ex.Message);
             }
         }
 

--- a/test/LightStep.Tests/MockLogProvider.cs
+++ b/test/LightStep.Tests/MockLogProvider.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using LightStep.Logging;
+using LightStep.Logging.LogProviders;
+
+namespace LightStep.Tests
+{
+    internal class MockLogProvider : ILogProvider
+    {
+        public Logger GetLogger(string name)
+        {
+            return Log;
+        }
+
+        public IDisposable OpenNestedContext(string message)
+        {
+            return new DisposableAction(() => { });
+        }
+
+        public IDisposable OpenMappedContext(string key, object value, bool destructure = false)
+        {
+            return new DisposableAction(() => { });
+        }
+
+        private static readonly object _lock = new object();
+
+        private static readonly List<Tuple<LogLevel, string, Exception>> Logs
+            = new List<Tuple<LogLevel, string, Exception>>();
+
+        private static bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception,
+            params object[] formatParameters)
+        {
+            string message = null;
+            if (messageFunc != null)
+            {
+                message = messageFunc();
+                if (formatParameters != null)
+                {
+                    message =
+                        LogMessageFormatter.FormatStructuredMessage(message,
+                            formatParameters,
+                            out _);
+                }
+            }
+
+            if (message != null || exception != null)
+            {
+                lock (_lock)
+                {
+                    Logs.Add(Tuple.Create(logLevel, message, exception));
+                }
+            }
+
+            return true;
+        }
+
+        public static Tuple<LogLevel, string, Exception>[] PurgeAndFetchLogs()
+        {
+            lock (_lock)
+            {
+                var result = Logs.ToArray();
+                Logs.Clear();
+                return result;
+            }
+        }
+
+        public class UseMockLogProviderScope : IDisposable
+        {
+            private readonly ILogProvider _oldLogProvider;
+
+            public UseMockLogProviderScope()
+            {
+                _oldLogProvider = LogProvider.CurrentLogProvider;
+                LogProvider.SetCurrentLogProvider(new MockLogProvider());
+            }
+
+            public void Dispose()
+            {
+                LogProvider.SetCurrentLogProvider(_oldLogProvider);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently the Span object throws exception when any actions are taken upon a finished span.
While this is an incorrect action, throwing an exception for an instrumentation library.
Modifying the result of this action to be a No-Op and simply log an error instead.