### PR TITLE
Use Task instead of void as return type in Tracer.Flush (#78)

### DIFF
--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -121,7 +121,7 @@ namespace LightStep
         ///     Transmits the current contents of the span buffer to the LightStep Satellite.
         ///     Note that this creates a copy of the current spans and clears the span buffer!
         /// </summary>
-        public async void Flush()
+        public async Task Flush()
         {
             if (_options.Run)
             {


### PR DESCRIPTION
Resolves #78 

It is best practice to avoid `async void` in method signatures because exceptions are not observed correctly. This commit changes the return type to a `Task`. 