### PR TITLE
Update csproj to use MIT license expression

### DIFF
--- a/src/LightStep/LightStep.csproj
+++ b/src/LightStep/LightStep.csproj
@@ -47,7 +47,7 @@
       <PackageReleaseNotes>https://github.com/lightstep/lightstep-tracer-csharp/blob/master/CHANGELOG.md</PackageReleaseNotes>
       <PackageIconUrl>https://raw.githubusercontent.com/lightstep/lightstep-tracer-csharp/master/ls128x128.png</PackageIconUrl>
       <PackageProjectUrl>http://www.lightstep.com</PackageProjectUrl>
-      <PackageLicenseUrl>https://raw.githubusercontent.com/lightstep/lightstep-tracer-csharp/blob/master/LICENSE</PackageLicenseUrl>
+      <PackageLicenseExpression>MIT</PackageLicenseExpression>
       <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
       <RepositoryType>git</RepositoryType>
       <RepositoryUrl>https://raw.githubusercontent.com/lightstep/lightstep-tracer-csharp</RepositoryUrl>


### PR DESCRIPTION
Fixes a build warning that PackageLicenseUrl is deprecated and PackageLicencseExpression should be used instead.