### PR TITLE
Ensure Flush is awaited when triggered by Tracer's internal timer

### DIFF
--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -67,8 +67,8 @@ namespace LightStep
             var url =
                 $"{protocol}://{_options.Satellite.SatelliteHost}:{_options.Satellite.SatellitePort}/{LightStepConstants.SatelliteReportPath}";
             _httpClient = client ?? new LightStepHttpClient(url, _options);
-            _logger.Debug($"Tracer is reporting to {url}.");          
-            _reportLoop = new Timer(e => Flush(), null, TimeSpan.Zero, _options.ReportPeriod);
+            _logger.Debug($"Tracer is reporting to {url}.");
+            _reportLoop = new Timer(async e => await Flush(), null, TimeSpan.Zero, _options.ReportPeriod);
             _firstReportHasRun = false;
         }
 


### PR DESCRIPTION
In #80 Flush's return type was updated to a Task so it could be correctly await. This fixes a usage of Flush in the Tracer's internal timer used to periodically flush spans using configured exporters.