### PR TITLE
fix(proto): improve serialization performance

### DIFF
--- a/src/LightStep/Collector/ProtoConverter.cs
+++ b/src/LightStep/Collector/ProtoConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Google.Protobuf.WellKnownTypes;
@@ -15,23 +15,8 @@ namespace LightStep.Collector
         /// <returns>Proto SpanContext</returns>
         public SpanContext MakeSpanContextFromOtSpanContext(LightStep.SpanContext ctx)
         {
-            try
-            {
-                SpanId = Convert.ToUInt64(ctx.SpanId);
-            }
-            catch (FormatException)
-            {
-                SpanId = Convert.ToUInt64(ctx.SpanId, 16);
-            }
-
-            try
-            {
-                TraceId = Convert.ToUInt64(ctx.TraceId);
-            }
-            catch (FormatException)
-            {
-                TraceId = Convert.ToUInt64(ctx.TraceId, 16);
-            }
+            SpanId = ctx.SpanIdValue;
+            TraceId = ctx.TraceIdValue;
             
             ctx.GetBaggageItems().ToList().ForEach(baggage => Baggage.Add(baggage.Key, baggage.Value));
             return this;

--- a/test/LightStep.Tests/LightStepProtoTests.cs
+++ b/test/LightStep.Tests/LightStepProtoTests.cs
@@ -145,5 +145,14 @@ namespace LightStep.Tests
                 }
             }
         }
+
+        [Fact]
+        public void SpanContextSpanIdShouldConvert()
+        {
+            var spanContext = new SpanContext(4659, 4660);
+            var protoSpanContext = new LightStep.Collector.SpanContext().MakeSpanContextFromOtSpanContext(spanContext);
+            Assert.Equal(4659ul, protoSpanContext.TraceId);
+            Assert.Equal(4660ul, protoSpanContext.SpanId);
+        }
     }
 }


### PR DESCRIPTION
closes #87

It looks like the conversion for protobuf would sometimes see the hex formatted strings as integers so it would get different span values on the conversion as well.