### PR TITLE
Refactor Translator out of ILightStepHttpClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+_v0.10.0_
+- Refactored several interfaces to allow integrators to re-implement the reporting HttpClient more easily.
+
 _v0.9.0_
 - Reduce logging verbosity and log output. Several statements that appeared at DEBUG now appear at TRACE.
 - Improve the resolution of span start/finish timestamps.

--- a/README.md
+++ b/README.md
@@ -62,3 +62,11 @@ var tracer = new Tracer(tracerOptions);
 ## Logging
 This tracer uses [LibLog](https://github.com/damianh/LibLog), a transparent logging abstraction that provides built-in support for NLog, Log4Net, Serilog, and Loupe.
 If you use a logging provider that isn't identified by LibLog, see [this gist](https://gist.github.com/damianh/fa529b8346a83f7f49a9) on how to implement a custom logging provider.
+
+## Integration Notes
+You may notice that there's a lot of overloads for creating a `Tracer`! You have the flexibility to override and re-implement much of this library. In 0.10.0+, the `ILightStepHttpClient` interface has
+been decoupled from report translation, allowing you control over the exact mechanism by which the tracer reports spans to Lightstep. You can reference [this issue](https://github.com/lightstep/lightstep-tracer-csharp/issues/92)
+for more information and a discussion about why you might want to do this.
+
+For most users, sticking with the defaults is fine. You should also look at the `Tracer(Options, IPropagator, ILightStepHttpClient)` ctor for custom integration - the span recorder and span translator overloads are not terribly interesting.
+Creating and managing propagators allows you to either select a built-in propagator (textmap, B3, etc.), create a propagator 'stack' (if you potentially have multiple input or output trace context formats), or write your own propagator.

--- a/src/LightStep/Collector/ILightStepHttpClient.cs
+++ b/src/LightStep/Collector/ILightStepHttpClient.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace LightStep.Collector
@@ -10,12 +11,5 @@ namespace LightStep.Collector
         /// <param name="report">An <see cref="ReportRequest" /></param>
         /// <returns>A <see cref="ReportResponse" />. This is usually not very interesting.</returns>
         Task<ReportResponse> SendReport(ReportRequest report);
-
-        /// <summary>
-        ///     Translate SpanData to a protobuf ReportRequest for sending to the Satellite.
-        /// </summary>
-        /// <param name="spans">An enumerable of <see cref="SpanData" /></param>
-        /// <returns>A <see cref="ReportRequest" /></returns>
-        ReportRequest Translate(ISpanRecorder spanBuffer);
     }
 }

--- a/src/LightStep/Collector/IReportTranslator.cs
+++ b/src/LightStep/Collector/IReportTranslator.cs
@@ -1,0 +1,12 @@
+namespace LightStep.Collector
+{
+    public interface IReportTranslator
+    {
+        /// <summary>
+        ///     Translate SpanData to a protobuf ReportRequest for sending to the Satellite.
+        /// </summary>
+        /// <param name="spans">An enumerable of <see cref="SpanData" /></param>
+        /// <returns>A <see cref="ReportRequest" /></returns>
+        ReportRequest Translate(ISpanRecorder spanBuffer);
+    }
+}

--- a/src/LightStep/Collector/ReportTranslator.cs
+++ b/src/LightStep/Collector/ReportTranslator.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
+using LightStep.Logging;
+
+namespace LightStep.Collector
+{
+    class ReportTranslator : IReportTranslator
+    {
+        private readonly Options _options;
+        private static readonly ILog _logger = LogProvider.GetCurrentClassLogger();
+
+        public ReportTranslator(Options options)
+        {
+            _options = options;
+        }
+
+        /// <summary>
+        ///     Translate SpanData to a protobuf ReportRequest for sending to the Satellite.
+        /// </summary>
+        /// <param name="spans">An enumerable of <see cref="SpanData" /></param>
+        /// <returns>A <see cref="ReportRequest" /></returns>
+        public ReportRequest Translate(ISpanRecorder spanBuffer)
+        {
+            _logger.Trace($"Serializing {spanBuffer.GetSpans().Count()} spans to proto.");
+            var timer = new Stopwatch();
+            timer.Start();
+
+            var request = new ReportRequest
+            {
+                Reporter = new Reporter
+                {
+                    ReporterId = _options.TracerGuid
+                },
+                Auth = new Auth { AccessToken = _options.AccessToken }
+            };
+            _options.Tags.ToList().ForEach(t => request.Reporter.Tags.Add(new KeyValue().MakeKeyValueFromKvp(t)));
+            spanBuffer.GetSpans().ToList().ForEach(span => {
+                try
+                {
+                    request.Spans.Add(new Span().MakeSpanFromSpanData(span));
+                }
+                catch (Exception ex)
+                {
+                    _logger.WarnException("Caught exception converting spans.", ex);
+                    spanBuffer.DroppedSpanCount++;
+                }
+            });
+
+            var metrics = new InternalMetrics
+            {
+                StartTimestamp = Timestamp.FromDateTime(spanBuffer.ReportStartTime.ToUniversalTime()),
+                DurationMicros = Convert.ToUInt64((spanBuffer.ReportEndTime - spanBuffer.ReportStartTime).Ticks / 10),
+                Counts = { new MetricsSample() { Name = "spans.dropped", IntValue = spanBuffer.DroppedSpanCount } }
+            };
+            request.InternalMetrics = metrics;
+
+            timer.Stop();
+            _logger.Trace($"Serialization complete in {timer.ElapsedMilliseconds}ms. Request size: {request.CalculateSize()}b.");
+
+            return request;
+        }
+    }
+}

--- a/src/LightStep/LightStepConstants.cs
+++ b/src/LightStep/LightStepConstants.cs
@@ -1,4 +1,4 @@
-﻿namespace LightStep
+namespace LightStep
 {
     /// <summary>
     ///     Constants and other values used by LightStep.
@@ -17,6 +17,8 @@
         public static readonly string TracerVersionKey = "lightstep.tracer_version";
 
         public static readonly string SatelliteReportPath = "api/v2/reports";
+
+        public static readonly string AccessTokenConstant = "Lightstep-Access-Token";
 
         public static class MetaEvent {
             public static readonly string MetaEventKey = "lightstep.meta_event";

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -50,18 +50,23 @@ namespace LightStep
             new AsyncLocalScopeManager(), propagator, options, spanRecorder, null)
         {
         }
-
+        /// <inheritdoc />
         public Tracer(Options options, ISpanRecorder spanRecorder, ILightStepHttpClient client) : this(
             new AsyncLocalScopeManager(), Propagators.TextMap, options, spanRecorder, client)
         {
         }
-
+        /// <inheritdoc />
+        public Tracer(Options options, IPropagator propagator, ILightStepHttpClient client) : this(
+            new AsyncLocalScopeManager(), propagator, options, new LightStepSpanRecorder(), client)
+        {
+        }
+        /// <inheritdoc />
         public Tracer(Options options, ISpanRecorder spanRecorder, IReportTranslator translator,
             ILightStepHttpClient client) : this(
             new AsyncLocalScopeManager(), Propagators.TextMap, options, spanRecorder, client, translator)
         {
         }
-
+        /// <inheritdoc />
         private Tracer(IScopeManager scopeManager, IPropagator propagator, Options options, ISpanRecorder spanRecorder, ILightStepHttpClient client, IReportTranslator translator = null)
         {
             ScopeManager = scopeManager;

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -20,6 +20,7 @@ namespace LightStep
         internal readonly Options _options;
         private readonly IPropagator _propagator;
         private readonly ILightStepHttpClient _httpClient;
+        private readonly IReportTranslator _translator;
         private ISpanRecorder _spanRecorder;
         private readonly Timer _reportLoop;
         private static readonly ILog _logger = LogProvider.GetCurrentClassLogger();
@@ -55,7 +56,13 @@ namespace LightStep
         {
         }
 
-        private Tracer(IScopeManager scopeManager, IPropagator propagator, Options options, ISpanRecorder spanRecorder, ILightStepHttpClient client)
+        public Tracer(Options options, ISpanRecorder spanRecorder, IReportTranslator translator,
+            ILightStepHttpClient client) : this(
+            new AsyncLocalScopeManager(), Propagators.TextMap, options, spanRecorder, client, translator)
+        {
+        }
+
+        private Tracer(IScopeManager scopeManager, IPropagator propagator, Options options, ISpanRecorder spanRecorder, ILightStepHttpClient client, IReportTranslator translator = null)
         {
             ScopeManager = scopeManager;
             _spanRecorder = spanRecorder;
@@ -67,6 +74,7 @@ namespace LightStep
             var url =
                 $"{protocol}://{_options.Satellite.SatelliteHost}:{_options.Satellite.SatellitePort}/{LightStepConstants.SatelliteReportPath}";
             _httpClient = client ?? new LightStepHttpClient(url, _options);
+            _translator = translator ?? new ReportTranslator(_options);
             _logger.Debug($"Tracer is reporting to {url}.");
             _reportLoop = new Timer(async e => await Flush().ConfigureAwait(false), null, TimeSpan.Zero, _options.ReportPeriod);
             _firstReportHasRun = false;
@@ -158,7 +166,7 @@ namespace LightStep
                 try
                 {
                     // since translate can throw exceptions, place it in the try and drop spans as appropriate
-                    var data = _httpClient.Translate(currentBuffer);
+                    var data = _translator.Translate(currentBuffer);
                     var resp = await _httpClient.SendReport(data).ConfigureAwait(false);
                     
                     if (resp.Errors.Count > 0)

--- a/test/LightStep.Tests/TracerTests.cs
+++ b/test/LightStep.Tests/TracerTests.cs
@@ -109,7 +109,7 @@ namespace LightStep.Tests
         }
 
         [Fact]
-        public void TracerShouldTrapExceptions()
+        public async void TracerShouldTrapExceptions()
         {
             var x = false;
             Action<Exception> eh = delegate { x = true; };
@@ -117,7 +117,8 @@ namespace LightStep.Tests
             var tracerOptions = new Options().WithSatellite(satelliteOptions).WithExceptionHandler(eh.Invoke);
             var recorder = new SimpleMockRecorder();
             var mockClient = new Mock<ILightStepHttpClient>();
-            mockClient.Setup(client => client.Translate(recorder)).Throws<OverflowException>();
+            var mockTranslator = new Mock<IReportTranslator>();
+            mockTranslator.Setup(translator => translator.Translate(recorder)).Throws<OverflowException>();
             
             var tracer = new Tracer(tracerOptions, recorder, mockClient.Object);
 
@@ -125,7 +126,7 @@ namespace LightStep.Tests
             span.Finish();
             
             Assert.False(x);
-            tracer.Flush();
+            await tracer.Flush();
             Assert.True(x);
         }
     }


### PR DESCRIPTION
This PR aims to make it easier to reimplement `ILightStepHttpClient` to allow integrators the flexibility to modify reporting to Lightstep Satellites.

