### PR TITLE
make tracer disposable

### DIFF
--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -14,7 +14,7 @@ using LightStep.Logging;
 namespace LightStep
 {
     /// <inheritdoc />
-    public sealed class Tracer : ITracer
+    public sealed class Tracer : ITracer, IDisposable
     {
         private readonly object _lock = new object();
         internal readonly Options _options;
@@ -225,6 +225,11 @@ namespace LightStep
                     _logger.Warn($"Dropping span due to too many spans in buffer.");
                 }
             }
+        }
+
+        public void Dispose()
+        {
+            _reportLoop?.Dispose();
         }
     }
 }


### PR DESCRIPTION
note that as this is modifying the tracer object it no longer directly complies with the OpenTracing ITracer interface, so you'll have to cast the tracer to dispose it.