### PR TITLE
Reduce unneeded 'toList' calls when getting count of spans in buffer

### DIFF
--- a/src/LightStep/Collector/ReportTranslator.cs
+++ b/src/LightStep/Collector/ReportTranslator.cs
@@ -26,7 +26,7 @@ namespace LightStep.Collector
         /// <returns>A <see cref="ReportRequest" /></returns>
         public ReportRequest Translate(ISpanRecorder spanBuffer)
         {
-            _logger.Trace($"Serializing {spanBuffer.GetSpans().Count()} spans to proto.");
+            _logger.Trace($"Serializing {spanBuffer.GetSpanCount()} spans to proto.");
             var timer = new Stopwatch();
             timer.Start();
 

--- a/src/LightStep/ISpanRecorder.cs
+++ b/src/LightStep/ISpanRecorder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace LightStep
@@ -49,5 +49,11 @@ namespace LightStep
         /// </summary>
         /// <returns></returns>
         IEnumerable<SpanData> GetSpans();
+
+        /// <summary>
+        /// Gets the count of spans in the buffer.
+        /// </summary>
+        /// <returns></returns>
+        int GetSpanCount();
     }
 }

--- a/src/LightStep/LightStepSpanRecorder.cs
+++ b/src/LightStep/LightStepSpanRecorder.cs
@@ -65,10 +65,8 @@ namespace LightStep
 
         public int GetSpanCount()
         {
-            lock (Spans)
-            {
-                return Spans.Count;
-            }
+
+            return Spans.Count;
         }
     }
 }

--- a/src/LightStep/LightStepSpanRecorder.cs
+++ b/src/LightStep/LightStepSpanRecorder.cs
@@ -62,5 +62,13 @@ namespace LightStep
                 return Spans.ToList();
             }
         }
+
+        public int GetSpanCount()
+        {
+            lock (Spans)
+            {
+                return Spans.Count;
+            }
+        }
     }
 }

--- a/src/LightStep/Tracer.cs
+++ b/src/LightStep/Tracer.cs
@@ -154,7 +154,7 @@ namespace LightStep
                 {
                     currentBuffer = _spanRecorder.GetSpanBuffer();
                     _spanRecorder = new LightStepSpanRecorder();
-                    _logger.Trace($"{currentBuffer.GetSpans().Count()} spans in buffer.");
+                    _logger.Trace($"{currentBuffer.GetSpanCount()} spans in buffer.");
                 }
                 
                 /**
@@ -198,8 +198,8 @@ namespace LightStep
                 {
                     lock (_lock)
                     {
-                        _logger.Warn($"Adding {currentBuffer.GetSpans().Count()} spans to dropped span count (current total: {currentDroppedSpanCount})");
-                        currentDroppedSpanCount += currentBuffer.GetSpans().Count();
+                        _logger.Warn($"Adding {currentBuffer.GetSpanCount()} spans to dropped span count (current total: {currentDroppedSpanCount})");
+                        currentDroppedSpanCount += currentBuffer.GetSpanCount();
                         if (this._options.ExceptionHandlerRegistered)
                         {
                             this._options.ExceptionHandler.Invoke(ex);
@@ -215,7 +215,7 @@ namespace LightStep
         {
             lock (_lock)
             {
-                if (_spanRecorder.GetSpans().Count() < _options.ReportMaxSpans )
+                if (_spanRecorder.GetSpanCount() < _options.ReportMaxSpans )
                 {
                     _spanRecorder.RecordSpan(span);
                 }

--- a/test/LightStep.Tests/SimpleMockRecorder.cs
+++ b/test/LightStep.Tests/SimpleMockRecorder.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace LightStep.Tests
 {
@@ -35,6 +36,11 @@ namespace LightStep.Tests
         public IEnumerable<SpanData> GetSpans()
         {
             return Spans;
+        }
+
+        public int GetSpanCount()
+        {
+            return Spans.Count();
         }
     }
 }


### PR DESCRIPTION
We were making an extra copy of the span buffer when getting the current span count.